### PR TITLE
Use Atom GitHub API Token

### DIFF
--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -27,6 +27,6 @@ module.exports =
 
 getTokenFromKeychain = (tokenName, callback) ->
   command = "security -q find-generic-password -ws '#{tokenName}'"
-  child_process.exec command, (error, stdout='', stderr='') ->
+  child_process.exec command, (error, stdout='') ->
     token = stdout.trim()
     callback(error, token)


### PR DESCRIPTION
This falls back to boxen's token if the atom token is not available. Also has a better error message.
