### PR TITLE
add theme & package search filter

### DIFF
--- a/src/search.coffee
+++ b/src/search.coffee
@@ -20,12 +20,21 @@ class Search extends Command
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
     options.boolean('json').describe('json', 'Output matching packages as JSON array')
+    options.boolean('packages').describe('packages', 'Search only non-theme packages').alias('p', 'packages')
+    options.boolean('themes').describe('themes', 'Search only themes').alias('t', 'themes')
 
-  searchPackages: (query, callback) ->
+  searchPackages: (query, opts, callback) ->
+    qs =
+      q: query
+
+    if opts.packages
+      qs.filter = 'package'
+    else if opts.themes
+      qs.filter = 'theme'
+
     requestSettings =
       url: "#{config.getAtomPackagesUrl()}/search"
-      qs:
-        q: query
+      qs: qs
       json: true
       proxy: process.env.http_proxy || process.env.https_proxy
 
@@ -50,7 +59,11 @@ class Search extends Command
       callback("Missing required search query")
       return
 
-    @searchPackages query, (error, packages) ->
+    searchOptions =
+      packages: options.argv.packages
+      themes: options.argv.themes
+
+    @searchPackages query, searchOptions, (error, packages) ->
       if error?
         callback(error)
         return


### PR DESCRIPTION
```
[apm (filter-search)⚡]> ./bin/apm help search

Usage: apm search <package_name>

Search for Atom packages/themes on the atom.io registry.

Options:
  --help, -h      Print this usage message              
  --json          Output matching packages as JSON array  [boolean]
  --packages, -p  Search only non-theme packages          [boolean]
  --themes, -t    Search only themes                      [boolean]

[apm (filter-search)⚡]> apm search -t syntax
Search Results For 'syntax' (10)
├── atom-dark-syntax Default dark theme for syntax
├── atom-light-syntax Default light syntax theme
├── fresh-syntax Fresh theme is.. fresh
├── green-syntax atom.io syntax highlighting inspired by the node js website
├── itg-dark-syntax Port of Sublime's itg-dark-theme to Atom.
├── itg-light-syntax Port of Sublime's itg-light-theme to Atom.
├── ninja-syntax Ninja syntax theme for Atom
├── ruby-blue-syntax Oh so blue
├── twilight-syntax Twilight syntax theme for GitHub's Atom IDE
└── winter-syntax A light theme with cool colors for the Atom editor.

Use `apm install` to install them or visit http://atom.io/packages to read more about them.

[apm (filter-search)⚡]> apm search -p syntax
Search Results For 'syntax' (7)
├── Atom-Syntax-highlighting-for-Sass Perfect syntax highlighting for both SCSS and Sass in Atom
├── cloud-sync Sync Files to Cloud Storage from Atom
├── language-syntax-settings Syntax-specific editor settings
├── package-sync Synchronizes packages installed between computers
├── ruby-syntax-replacer Will replace all old Ruby hash syntax with new
├── syntax-settings Syntax specific settings there in your config.
└── zentabs Keep the opened tabs amount below specified limit

Use `apm install` to install them or visit http://atom.io/packages to read more about them.
```
