### PR TITLE
bugfix; install: use mv-module to move nodejs instead of fs.rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "tar": "~0.1.19",
     "git-utils": "1.x",
     "semver": "~2.2.1",
+    "mv": "2.0.0",
     "open": "0.0.4"
   },
   "devDependencies": {

--- a/script/download-node.js
+++ b/script/download-node.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 var fs = require('fs');
+var mv = require('mv');
 var zlib = require('zlib');
 var path = require('path');
 var request = require('request');
@@ -29,7 +30,7 @@ var copyNodeBinToLocation = function(callback, version, targetFilename, fromDire
   var arch = process.arch === 'ia32' ? 'x86' : process.arch;
   var subDir = "node-" + version + "-" + process.platform + "-" + arch;
   var fromPath = path.join(fromDirectory, subDir, 'bin', 'node');
-  return fs.rename(fromPath, targetFilename, callback);
+  return mv(fromPath, targetFilename, callback);
 };
 
 var downloadNode = function(version, done) {


### PR DESCRIPTION
Fixes #91
