### PR TITLE
Set node bin's permission as 755

### DIFF
--- a/script/download-node.js
+++ b/script/download-node.js
@@ -30,7 +30,13 @@ var copyNodeBinToLocation = function(callback, version, targetFilename, fromDire
   var arch = process.arch === 'ia32' ? 'x86' : process.arch;
   var subDir = "node-" + version + "-" + process.platform + "-" + arch;
   var fromPath = path.join(fromDirectory, subDir, 'bin', 'node');
-  return mv(fromPath, targetFilename, callback);
+  return mv(fromPath, targetFilename, function(err) {
+    if (err) {
+      callback(err);
+      return;
+    }
+    fs.chmod(targetFilename, "755", callback);
+  });
 };
 
 var downloadNode = function(version, done) {


### PR DESCRIPTION
When "mv" is executed beyond mount devices, it simply move file data,
but it doesn't set original permission.
In this time, we guarantees that node bin's permission is 755 since
it will be executed as an executable file later.
