### PR TITLE
Fix class name collision

### DIFF
--- a/src/view.coffee
+++ b/src/view.coffee
@@ -7,7 +7,7 @@ config = require './config'
 tree = require './tree'
 
 module.exports =
-class Search extends Command
+class View extends Command
   @commandNames: ['view', 'show']
 
   parseOptions: (argv) ->


### PR DESCRIPTION
`src/search.coffee` is overwritten by `src/view.coffee`
