### PR TITLE
don't throw an error (#getVisualStudioFlags)

### DIFF
--- a/src/install.coffee
+++ b/src/install.coffee
@@ -118,7 +118,7 @@ class Install extends Command
     if vsVersion = config.getInstalledVisualStudioFlag()
       "--msvs_version=#{vsVersion}"
     else
-      throw new Error('You must have Visual Studio 2010 or 2012 installed')
+      null
 
   installModules: (options, callback) =>
     process.stdout.write 'Installing modules '


### PR DESCRIPTION
Should we _really_ throw an error if Visual Studio is not installed on Windows? I've tried to install packages in Windows build without Python and Visual Studio and everything works well.
