### PR TITLE
request proxy options update

### DIFF
--- a/script/download-node.js
+++ b/script/download-node.js
@@ -25,7 +25,7 @@ var downloadTarballAndExtract = function(url, location, callback) {
   stream.on('error', callback);
   var requestOptions = {
     url: url,
-    proxy: process.env.http_proxy || process.env.https_proxy
+    proxy: process.env.http_proxy || process.env.https_proxy || process.env.HTTP_PROXY || process.env.HTTPS_PROXY
   };
   return request(requestOptions).pipe(zlib.createGunzip()).pipe(stream);
 };


### PR DESCRIPTION
Unfortunately if my env variables are uppercase or some other weird combination it will fail (at least it does on a Windows machine) and you will always get a `connection refused` error. So this should be able to fix all common cases.
