### PR TITLE
Add common aliases for the `uninstall` subcommand

### DIFF
--- a/src/uninstall.coffee
+++ b/src/uninstall.coffee
@@ -8,7 +8,7 @@ fs = require './fs'
 
 module.exports =
 class Uninstall extends Command
-  @commandNames: ['deinstall'. 'delete', 'erase', 'remove', 'rm', 'uninstall']
+  @commandNames: ['deinstall', 'delete', 'erase', 'remove', 'rm', 'uninstall']
 
   parseOptions: (argv) ->
     options = optimist(argv)


### PR DESCRIPTION
Currently, `apm` only understands `uninstall` as the subcommand to reverse to installing a package. While this seems sane and symmetrical, there are many other package managers that do this in slightly different ways. To avoid papercuts of commands not being recognised and to exploit the the users' muscle memory, `apm` should have aliases for the equivalent commands of other package managers. Here are a collection of names for the subcommand inverse to `install` from other package managers:

Operating Systems:
- [Arch's Pacman: `-R` and `--remove`](https://www.archlinux.org/pacman/pacman.8.html)
- [Debian's DPKG: `deinstall`](http://manpages.debian.org/cgi-bin/man.cgi?query=dpkg)
- [DEB's APT-GET: `remove`](http://linux.die.net/man/8/apt-get)
- [Mac OS's Homebrew: `uninstall`](https://github.com/Homebrew/homebrew/wiki/FAQ#how-do-i-uninstall-a-formula)
- [Mac OS's BacPorts: `uninstall`](https://guide.macports.org/#using.port.uninstall)
- [OpenWRT's OPKG: `remove`](http://wiki.openwrt.org/doc/techref/opkg)
- [RPM's YUM: `erase` and `remove`](http://linux.die.net/man/8/yum)
- [Window's WPKG: `-r` and `--remove`](http://windowspackager.org/documentation/wpkg/wpkg-remove-r)

Programming Languages:
- [.Net's Nuget: `delete`](http://docs.nuget.org/docs/reference/command-line-reference#Delete_Command)
- [Go-Lang: _None_](http://golang.org/cmd/go/#hdr-Download_and_install_packages_and_dependencies)
- [Haskel's Cabal: _None_](http://www.haskell.org/haskellwiki/Cabal-Install#How_can_I_uninstall_packages.3F)
- [Javascript's Bower: `uninstall`](http://bower.io/#uninstalling-packages)
- [Javascript's Jam: `remove`](http://jamjs.org/docs#Removing)
- [Node's NPM: `rm`](https://www.npmjs.org/doc/cli/npm-rm.html)
- [Python's pip: `uninstall`](http://pip.readthedocs.org/en/latest/user_guide.html#uninstalling-packages)
- [PHP's Composer: `--no-dev update`](http://stackoverflow.com/questions/13744340/is-there-a-way-to-uninstall-dev-dependencies-with-composer) [Yes, really.]
- [PHP's Pear: `uninstall`](http://www.manpagez.com/man/1/pear/)

Should we also alias `install` to `add`, to preserve the symmetry?
- add - delete
- add - erase
- add - remove
- add  - rm
- install - uninstall
- install - deinstall
