### PR TITLE
Fix module version mismatch. Expected 11, got 13.

### DIFF
--- a/script/download-node.js
+++ b/script/download-node.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var mv = require('mv');
 var zlib = require('zlib');
 var path = require('path');
+var semver = require('semver');
 
 // Use whichever version of the local request helper is available
 // This might be the JavaScript or CoffeeScript version depending
@@ -78,7 +79,16 @@ var downloadNode = function(version, done) {
   }
 };
 
-downloadNode('v0.10.26', function(error) {
+var nodeVersion = function () {
+  var version;
+  if (semver.satisfies(process.version, '>0.10.26')) {
+    return process.version;
+  } else {
+    return 'v0.10.26';
+  }
+}
+
+downloadNode(nodeVersion(), function(error) {
   if (error != null) {
     console.error('Failed to download node', error);
     return process.exit(1);


### PR DESCRIPTION
I think this bug has been known before (atom/atom#2101, #21). It seems that at the moment atom (or apm) is bundling v0.10.26 with apm even if atom is build using a newer version (v0.10.28 in my case).

Or is this a wanted behavior? In that case I'm sorry, forget about my PR. :wink:
