### PR TITLE
Fix template `view-spec`

### DIFF
--- a/templates/package/spec/__package-name__-view-spec.coffee.template
+++ b/templates/package/spec/__package-name__-view-spec.coffee.template
@@ -2,4 +2,4 @@ __PackageName__View = require '../lib/__package-name__-view'
 
 describe "__PackageName__View", ->
   it "has one valid test", ->
-    expect("life").toBe "easy"
+    expect("life").toBe "life"


### PR DESCRIPTION
Fix the test case "has one valid test" in the template, because it fails due to the string "life" is not equal to the string "easy".

Previously
![capture du 2014-06-17 20 17 32](https://cloud.githubusercontent.com/assets/1688162/3304516/b4ffb884-f64b-11e3-9321-3c02feff4baf.png)

After the fix
![capture du 2014-06-17 20 19 45](https://cloud.githubusercontent.com/assets/1688162/3304548/24197926-f64c-11e3-859e-c77cd769f826.png)
