### PR TITLE
Ensure `apm test` works correctly for chocolatey-installed Atom on Windows

### DIFF
--- a/src/test.coffee
+++ b/src/test.coffee
@@ -35,6 +35,12 @@ class Test extends Command
     testArgs = ['--dev', '--test', "--spec-directory=#{path.join(packagePath, 'spec')}"]
 
     if process.platform is 'win32'
+      unless args.argv.path?
+        atomCommand = path.join(env.ALLUSERSPROFILE, 'chocolatey', 'bin', 'atom.exe') if env.ALLUSERSPROFILE? and env.ALLUSERSPROFILE.trim() isnt ''
+        atomCommand = path.join(env.CHOCOLATEYINSTALL, 'bin', 'atom.exe') if env.CHOCOLATEYINSTALL? and env.CHOCOLATEYINSTALL.trim() isnt ''
+        atomCommand = 'atom' unless fs.existsSync(atomCommand)
+
+      testArgs.unshift('--shimgen-waitforexit')
       logFile = temp.openSync(suffix: '.log', prefix: "#{path.basename(packagePath)}-")
       fs.closeSync(logFile.fd)
       logFilePath = logFile.path


### PR DESCRIPTION
Fixes https://github.com/atom/chocolatey/issues/23 - @kevinsawicki

Example output:

```
c:\projects\go-plus>apm test
[2664:0713/213953:ERROR:gpu_info_collector_win.cc(102)] Can't retrieve a valid WinSAT assessment.
[2664:0713/213954:INFO:CONSOLE(0)] Application server failed { [Error: listen EADDRINUSE] code: 'EADDRINUSE', errno: 'EA
DDRINUSE', syscall: 'listen' }
[3748:0713/213954:INFO:renderer_main.cc(227)] Renderer process started
[2664:0713/213954:ERROR:cache_util_win.cc(20)] Unable to move the cache: 5
[2664:0713/213954:ERROR:cache_util.cc(104)] Unable to move cache folder C:\Users\vagrant\AppData\Roaming\Atom\GPUCache t
o C:\Users\vagrant\AppData\Roaming\Atom\old_GPUCache_000
[2664:0713/213954:ERROR:cache_creator.cc(115)] Unable to create cache
[2664:0713/213954:ERROR:shader_disk_cache.cc(580)] Shader Cache Creation failed: -2
warning: removing Breakpad handler out of order
...................................

Finished in 5.485 seconds
35 tests, 182 assertions, 0 failures, 0 skipped


Tests passed
```

Also, it works when not using the Chocolatey shim:

```
c:\projects\go-plus>apm test --path c:\ProgramData\chocolatey\lib\Atom.0.115.0\tools\Atom\atom.exe
[3852:0713/214343:ERROR:gpu_info_collector_win.cc(102)] Can't retrieve a valid WinSAT assessment.
[3852:0713/214344:INFO:CONSOLE(0)] Application server failed { [Error: listen EADDRINUSE] code: 'EADDRINUSE', errno: 'EA
DDRINUSE', syscall: 'listen' }
[2492:0713/214344:INFO:renderer_main.cc(227)] Renderer process started
[3852:0713/214344:ERROR:cache_util_win.cc(20)] Unable to move the cache: 5
[3852:0713/214344:ERROR:cache_util.cc(104)] Unable to move cache folder C:\Users\vagrant\AppData\Roaming\Atom\GPUCache t
o C:\Users\vagrant\AppData\Roaming\Atom\old_GPUCache_000
[3852:0713/214344:ERROR:cache_creator.cc(115)] Unable to create cache
[3852:0713/214344:ERROR:shader_disk_cache.cc(580)] Shader Cache Creation failed: -2
warning: removing Breakpad handler out of order
...................................

Finished in 5.391 seconds
35 tests, 182 assertions, 0 failures, 0 skipped


Tests passed
```
