### PR TITLE
WIP: add --json flag to apm ls

### DIFF
--- a/src/list.coffee
+++ b/src/list.coffee
@@ -107,8 +107,9 @@ class List extends Command
   listInstalledPackages: (options) ->
     @listDevPackages options, (error, packages) =>
       @logPackages(packages, options)
-    @listUserPackages options, (error, packages) =>
-      @logPackages(packages, options)
+
+      @listUserPackages options, (error, packages) =>
+        @logPackages(packages, options)
 
   listPackagesAsJson: (options) ->
     output =


### PR DESCRIPTION
This adds a `--json` flag to `apm ls`, grouping output in a json object under the keys `core`, `dev`, and `user`. This should be handy for things like showing packages grouped by these categories in the Atom settings view.
#### TODO:
- [x] Fix output of bundled packages to include more than just the package name
