### PR TITLE
Add instruction to install libgnome-keyring-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ able to run it from a terminal.
 
 ## Building
   * Clone the repository
+  * Install `libgnome-keyring-dev` if it is not installed
   * Run `npm install`
   * Run `grunt` to compile the CoffeeScript code
   * Run `npm test` to run the specs


### PR DESCRIPTION
It is doing this in the TravisCI test ([reference](https://github.com/atom/apm/blob/master/.travis.yml#L11)).

---

If not do so, get such error message...

```
$ sudo cnpm install

> keytar@2.0.3 install /home/lijunle/Repositories/apm/node_modules/keytar
> node-gyp rebuild

Package gnome-keyring-1 was not found in the pkg-config search path.
Perhaps you should add the directory containing `gnome-keyring-1.pc'
to the PKG_CONFIG_PATH environment variable
No package 'gnome-keyring-1' found
gyp: Call to 'pkg-config --libs-only-l gnome-keyring-1' returned exit status 1. while trying to load binding.gyp
gyp ERR! configure error 
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/usr/local/lib/node_modules/cnpm/node_modules/npm/node_modules/node-gyp/lib/configure.js:343:16)
gyp ERR! stack     at ChildProcess.EventEmitter.emit (events.js:98:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:797:12)
gyp ERR! System Linux 3.13.0-40-generic
gyp ERR! command "node" "/usr/local/lib/node_modules/cnpm/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/lijunle/Repositories/apm/node_modules/keytar
gyp ERR! node -v v0.10.25
gyp ERR! node-gyp -v v0.13.1
gyp ERR! not ok 
npm ERR! keytar@2.0.3 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the keytar@2.0.3 install script.
npm ERR! This is most likely a problem with the keytar package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls keytar
npm ERR! There is likely additional logging output above.

npm ERR! System Linux 3.13.0-40-generic
npm ERR! command "node" "/usr/local/lib/node_modules/cnpm/node_modules/.bin/npm" "--userconfig=/home/lijunle/.cnpmrc" "--disturl=http://npm.taobao.org/dist" "--cache=/home/lijunle/.npm/.cache_cnpm" "--registry=http://registry.npm.taobao.org" "install"
npm ERR! cwd /home/lijunle/Repositories/apm
npm ERR! node -v v0.10.25
npm ERR! npm -v 1.4.14
npm ERR! code ELIFECYCLE

> coffeelint@0.5.7 install /home/lijunle/Repositories/apm/node_modules/grunt-coffeelint/node_modules/coffeelint
> [ -e lib/commandline.js ] || npm run compile

npm WARN package.json github-url-from-git@1.1.1 No repository field.
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/lijunle/Repositories/apm/npm-debug.log
npm ERR! not ok code 0
```
