### PR TITLE
Add verbose argument for install command.

### DIFF
--- a/src/install.coffee
+++ b/src/install.coffee
@@ -124,7 +124,6 @@ class Install extends Command
       nodeModulesDirectory = path.join(installDirectory, 'node_modules')
       fs.makeTreeSync(nodeModulesDirectory)
       installOptions.cwd = installDirectory
-      installOptions.streaming = true if @verbose
 
     @fork @atomNpmPath, installArgs, installOptions, (code, stderr='', stdout='') =>
       if code is 0


### PR DESCRIPTION
This command will set `request` to debug mode to output logs.

This export the hack of #174 as `--verbose` argument.

---

<del>I find a bug for this PR, but DO NOT merge it.</del> **Resolved!**
