### PR TITLE
Allow Repositories To DIffer Between Versions

### DIFF
--- a/spec/upgrade-spec.coffee
+++ b/spec/upgrade-spec.coffee
@@ -106,6 +106,18 @@ describe "apm upgrade", ->
       expect(console.log).toHaveBeenCalled()
       expect(console.log.argsForCall[1][0]).toContain 'different-repo 0.3.0 -> 0.4.0'
 
+  it "does not display updates when the installed package's repository does not exist", ->
+    fs.writeFileSync(path.join(packagesDir, 'different-repo', 'package.json'), JSON.stringify({name: 'different-repo', version: '0.3.0'}))
+
+    callback = jasmine.createSpy('callback')
+    apm.run(['upgrade', '--list', '--no-color'], callback)
+
+    waitsFor 'waiting for upgrade to complete', 600000, ->
+      callback.callCount > 0
+
+    runs ->
+      expect(console.log).toHaveBeenCalled()
+      expect(console.log.argsForCall[1][0]).toContain 'empty'
 
   it "logs an error when the installed location of Atom cannot be found", ->
     process.env.ATOM_RESOURCE_PATH = '/tmp/atom/is/not/installed/here'

--- a/src/upgrade.coffee
+++ b/src/upgrade.coffee
@@ -91,10 +91,13 @@ class Upgrade extends Command
 
           latestVersion = version if semver.gt(version, latestVersion)
 
-        if latestVersion isnt pack.version
+        if latestVersion isnt pack.version and @hasRepo(pack)
           callback(null, {pack, latestVersion})
         else
           callback()
+
+  hasRepo: (packageA) ->
+    repo = Packages.getRepository(packageA)
 
   getAvailableUpdates: (packages, callback) ->
     async.map packages, @getLatestVersion.bind(this), (error, updates) =>


### PR DESCRIPTION
- Allows migration of a package betwene github accounts
- Fixes #229
