### PR TITLE
Update featured command to match current API

### DIFF
--- a/spec/featured-spec.coffee
+++ b/spec/featured-spec.coffee
@@ -11,12 +11,15 @@ describe 'apm featured', ->
     spyOnToken()
 
     app = express()
-    app.get '/featured', (request, response) ->
-      response.sendfile path.join(__dirname, 'fixtures', 'available.json')
+    app.get '/packages/featured', (request, response) ->
+      response.sendfile path.join(__dirname, 'fixtures', 'packages.json')
+    app.get '/themes/featured', (request, response) ->
+      response.sendfile path.join(__dirname, 'fixtures', 'themes.json')
+
     server =  http.createServer(app)
     server.listen(3000)
 
-    process.env.ATOM_PACKAGES_URL = "http://localhost:3000"
+    process.env.ATOM_API_URL = "http://localhost:3000"
 
   afterEach ->
     server.close()
@@ -33,7 +36,7 @@ describe 'apm featured', ->
       expect(console.log.argsForCall[1][0]).toContain 'beverly-hills'
 
   describe 'when the theme flag is specified', ->
-    it "only lists themes", ->
+    it "lists the featured themes", ->
       callback = jasmine.createSpy('callback')
       apm.run(['featured', '--themes'], callback)
 

--- a/spec/fixtures/packages.json
+++ b/spec/fixtures/packages.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "beverly-hills",
+    "releases": {
+      "latest": "9.0.2.1.0"
+    },
+    "metadata": {
+      "name": "beverly-hills",
+      "version": "9.0.2.1.0",
+      "description": "Home of the peach pit after dark"
+    }
+  },
+  {
+    "name": "multi-version",
+    "releases": {
+      "latest": "2.0.0",
+      "other": "1.0.0"
+    },
+    "metadata": {
+      "name": "multi-version",
+      "version": "2.0.0"
+    }
+  }
+]

--- a/spec/fixtures/themes.json
+++ b/spec/fixtures/themes.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "duckblur",
+    "releases": {
+      "latest": "19.92"
+    },
+    "metadata": {
+      "name": "duckblur",
+      "version": "19.92",
+      "theme": true,
+      "description": "Racecars, lasers, airplanes"
+    }
+  }
+]

--- a/src/featured.coffee
+++ b/src/featured.coffee
@@ -26,11 +26,11 @@ class Featured extends Command
     options.alias('c', 'compatible').string('compatible').describe('compatible', 'Only list packages/themes compatible with this Atom version')
     options.boolean('json').describe('json', 'Output featured packages as JSON array')
 
-  getFeaturedPackages: (atomVersion, callback) ->
+  getFeaturedPackages: (atomVersion, packageType, callback) ->
     [callback, atomVersion] = [atomVersion, null] if _.isFunction(atomVersion)
 
     requestSettings =
-      url: "#{config.getAtomPackagesUrl()}/featured"
+      url: "#{config.getAtomApiUrl()}/#{packageType}/featured"
       json: true
     requestSettings.qs = engine: atomVersion if atomVersion
 
@@ -50,13 +50,12 @@ class Featured extends Command
     {callback} = options
     options = @parseOptions(options.commandArgs)
 
-    @getFeaturedPackages options.argv.compatible, (error, packages) ->
+    packageType = if options.argv.themes then 'themes' else 'packages'
+
+    @getFeaturedPackages options.argv.compatible, packageType, (error, packages) ->
       if error?
         callback(error)
         return
-
-      if options.argv.themes
-        packages = packages.filter ({theme}) -> theme
 
       if options.argv.json
         console.log(JSON.stringify(packages))


### PR DESCRIPTION
The featured API uses two endpoints for packages and themes, not one. The code expected to get packages and themes together in one call, which is not the case with the (admittedly undocumented) featured package and theme endpoints. This PR updates the code and tests to use the correct endpoints.
