### PR TITLE
Add config command

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1,0 +1,51 @@
+path = require 'path'
+fs = require 'fs-plus'
+temp = require 'temp'
+apm = require '../lib/apm-cli'
+
+describe "apm config", ->
+  [atomHome, userConfigPath] = []
+
+  beforeEach ->
+    spyOnToken()
+    silenceOutput()
+
+    atomHome = temp.mkdirSync('apm-home-dir-')
+    process.env.ATOM_HOME = atomHome
+    userConfigPath = path.join(atomHome, '.apmrc')
+
+    # Make sure the cache used is the one for the test env
+    delete process.env.npm_config_cache
+
+  describe "apm config get", ->
+    it "reads the value from the global config where there is no user config", ->
+      callback = jasmine.createSpy('callback')
+      apm.run(['config', 'get', 'cache'], callback)
+
+      waitsFor 'waiting for config get to complete', 600000, ->
+        callback.callCount is 1
+
+      runs ->
+        expect(process.stdout.write.argsForCall[0][0].trim()).toBe path.join(process.env.ATOM_HOME, '.node-gyp', '.atom', '.apm')
+
+  describe "apm config set", ->
+    it "sets the value in the user config", ->
+      expect(fs.isFileSync(userConfigPath)).toBe false
+
+      callback = jasmine.createSpy('callback')
+      apm.run(['config', 'set', 'foo', 'bar'], callback)
+
+      waitsFor 'waiting for config set to complete', 600000, ->
+        callback.callCount is 1
+
+      runs ->
+        expect(fs.isFileSync(userConfigPath)).toBe true
+
+        callback.reset()
+        apm.run(['config', 'get', 'foo'], callback)
+
+      waitsFor 'waiting for config get to complete', 600000, ->
+        callback.callCount is 1
+
+      runs ->
+        expect(process.stdout.write.argsForCall[0][0].trim()).toBe 'bar'

--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -99,7 +99,7 @@ describe 'apm install', ->
 
       describe "when the package is already in the cache", ->
         it "installs it from the cache", ->
-          cachePath = path.join(require('../lib/config').getPackageCacheDirectory(), 'test-module2', '2.0.0', 'package.tgz')
+          cachePath = path.join(require('../lib/apm').getPackageCacheDirectory(), 'test-module2', '2.0.0', 'package.tgz')
           testModuleDirectory = path.join(atomHome, 'packages', 'test-module2')
 
           callback = jasmine.createSpy('callback')

--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -24,6 +24,7 @@ setupTempDirectory()
 
 commandClasses = [
   require './clean'
+  require './config'
   require './dedupe'
   require './develop'
   require './docs'

--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -7,7 +7,7 @@ npm = require 'npm'
 optimist = require 'optimist'
 wordwrap = require 'wordwrap'
 
-config = require './config'
+config = require './apm'
 fs = require './fs'
 
 setupTempDirectory = ->

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -1,1 +1,128 @@
-module.exports = {}
+child_process = require 'child_process'
+fs = require './fs'
+path = require 'path'
+npm = require 'npm'
+semver = require 'npm/node_modules/semver'
+
+module.exports =
+  getHomeDirectory: ->
+    if process.platform is 'win32' then process.env.USERPROFILE else process.env.HOME
+
+  getAtomDirectory: ->
+    process.env.ATOM_HOME ? path.join(@getHomeDirectory(), '.atom')
+
+  getPackageCacheDirectory: ->
+    path.join(@getAtomDirectory(), '.node-gyp', '.atom', '.apm')
+
+  getResourcePath: (callback) ->
+    if process.env.ATOM_RESOURCE_PATH
+      process.nextTick -> callback(process.env.ATOM_RESOURCE_PATH)
+    else
+      apmFolder = path.resolve(__dirname, '..', '..', '..')
+      appFolder = path.dirname(apmFolder)
+      if path.basename(apmFolder) is 'apm' and path.basename(appFolder) is 'app'
+        process.nextTick -> callback(appFolder)
+      else
+        switch process.platform
+          when 'darwin'
+            child_process.exec 'mdfind "kMDItemCFBundleIdentifier == \'com.github.atom\'"', (error, stdout='', stderr) ->
+              appLocation = stdout.split('\n')[0] ? '/Applications/Atom.app'
+              callback("#{appLocation}/Contents/Resources/app")
+          when 'linux'
+            process.nextTick -> callback('/usr/local/share/atom/resources/app')
+          when 'win32'
+            process.nextTick =>
+              programFilesPath = path.join(process.env.ProgramFiles, 'Atom', 'resources', 'app')
+
+              # Scan for latest chocolatey install version when not in program files
+              unless fs.isDirectorySync(programFilesPath)
+                if process.env.CHOCOLATEYINSTALL
+                  chocolateyLibPath = path.join(process.env.CHOCOLATEYINSTALL, 'lib')
+
+                if process.env.ALLUSERSPROFILE and not fs.isDirectorySync(chocolateyLibPath)
+                  chocolateyLibPath = path.join(process.env.ALLUSERSPROFILE, 'chocolatey', 'lib')
+
+                latestVersion = null
+                for child in fs.list(chocolateyLibPath)
+                  if child.indexOf('Atom.') is 0
+                    version = child.substring(5)
+                    if semver.valid(version)
+                      latestVersion ?= version
+                      latestVersion = version if semver.gt(version, latestVersion)
+
+                if latestVersion
+                  appLocation = path.join(chocolateyLibPath, "Atom.#{version}", 'tools', 'Atom', 'resources', 'app')
+                  return callback(appLocation) if fs.isDirectorySync(appLocation)
+
+              callback(programFilesPath)
+
+  getReposDirectory: ->
+    process.env.ATOM_REPOS_HOME ? path.join(@getHomeDirectory(), 'github')
+
+  getNodeUrl: ->
+    process.env.ATOM_NODE_URL ? 'https://gh-contractor-zcbenz.s3.amazonaws.com/atom-shell/dist'
+
+  getAtomPackagesUrl: ->
+    process.env.ATOM_PACKAGES_URL ? "#{@getAtomApiUrl()}/packages"
+
+  getAtomApiUrl: ->
+    process.env.ATOM_API_URL ? 'https://atom.io/api'
+
+  getNodeVersion: ->
+    process.env.ATOM_NODE_VERSION ? '0.20.0'
+
+  getNodeArch: ->
+    switch process.platform
+      when 'darwin' then 'x64'
+      when 'win32' then 'ia32'
+      else process.arch  # On BSD and Linux we use current machine's arch.
+
+  getUserConfigPath: ->
+    path.resolve(@getAtomDirectory(), '.apmrc')
+
+  getGlobalConfigPath: ->
+    path.resolve(__dirname, '..', '.apmrc')
+
+  isWin32: ->
+    process.platform is 'win32'
+
+  isWindows64Bit: ->
+    fs.existsSync "C:\\Windows\\SysWow64\\Notepad.exe"
+
+  x86ProgramFilesDirectory: ->
+    process.env["ProgramFiles(x86)"] or process.env["ProgramFiles"]
+
+  getInstalledVisualStudioFlag: ->
+    return null unless @isWin32()
+
+    # Use the explictly-configured version when set
+    return process.env.GYP_MSVS_VERSION if process.env.GYP_MSVS_VERSION
+
+    vs2013Path = path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio 12.0", "Common7", "IDE")
+    return '2013' if fs.existsSync(vs2013Path)
+
+    vs2012Path = path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio 11.0", "Common7", "IDE")
+    return '2012' if fs.existsSync(vs2012Path)
+
+    vs2010Path = path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio 10.0", "Common7", "IDE")
+    return '2010' if fs.existsSync(vs2010Path)
+
+  loadNpm: (callback) ->
+    npmOptions =
+      userconfig: @getUserConfigPath()
+      globalconfig: @getGlobalConfigPath()
+    npm.load npmOptions, -> callback(null, npm)
+
+  getSetting: (key, callback) ->
+    @loadNpm -> callback(npm.config.get(key))
+
+  getChocolateyAtomPath: ->
+    if process.env.CHOCOLATEYINSTALL
+      atomCommand = path.join(process.env.CHOCOLATEYINSTALL, 'bin', 'atom.exe')
+      return atomCommand if fs.existsSync(atomCommand)
+
+    if process.env.ALLUSERSPROFILE
+      atomCommand = path.join(process.env.ALLUSERSPROFILE, 'chocolatey', 'bin', 'atom.exe')
+      return atomCommand if fs.existsSync(atomCommand)
+
+    null

--- a/src/clean.coffee
+++ b/src/clean.coffee
@@ -6,7 +6,7 @@ optimist = require 'optimist'
 _ = require 'underscore-plus'
 
 Command = require './command'
-config = require './config'
+config = require './apm'
 fs = require './fs'
 
 module.exports =

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1,128 +1,43 @@
-child_process = require 'child_process'
-fs = require './fs'
 path = require 'path'
-npm = require 'npm'
-semver = require 'npm/node_modules/semver'
+_ = require 'underscore-plus'
+optimist = require 'optimist'
+apm = require './apm'
+Command = require './command'
 
 module.exports =
-  getHomeDirectory: ->
-    if process.platform is 'win32' then process.env.USERPROFILE else process.env.HOME
+class Config extends Command
+  @commandNames: ['config']
 
-  getAtomDirectory: ->
-    process.env.ATOM_HOME ? path.join(@getHomeDirectory(), '.atom')
+  constructor: ->
+    atomDirectory = apm.getAtomDirectory()
+    @atomNodeDirectory = path.join(atomDirectory, '.node-gyp')
+    @atomNpmPath = require.resolve('npm/bin/npm-cli')
 
-  getPackageCacheDirectory: ->
-    path.join(@getAtomDirectory(), '.node-gyp', '.atom', '.apm')
+  parseOptions: (argv) ->
+    options = optimist(argv)
+    options.usage """
 
-  getResourcePath: (callback) ->
-    if process.env.ATOM_RESOURCE_PATH
-      process.nextTick -> callback(process.env.ATOM_RESOURCE_PATH)
-    else
-      apmFolder = path.resolve(__dirname, '..', '..', '..')
-      appFolder = path.dirname(apmFolder)
-      if path.basename(apmFolder) is 'apm' and path.basename(appFolder) is 'app'
-        process.nextTick -> callback(appFolder)
+      Usage: apm config set <key> <value>
+             apm config get <key>
+             apm config delete <key>
+             apm config list
+             apm config edit
+
+    """
+    options.alias('h', 'help').describe('help', 'Print this usage message')
+
+  run: (options) ->
+    {callback, cwd} = options
+    options = @parseOptions(options.commandArgs)
+
+    configArgs = ['--globalconfig', apm.getGlobalConfigPath(), '--userconfig', apm.getUserConfigPath(), 'config']
+    configArgs = configArgs.concat(options.argv._)
+
+    env = _.extend({}, process.env, HOME: @atomNodeDirectory)
+    configOptions = {env, streaming: true}
+
+    @fork @atomNpmPath, configArgs, configOptions, (code, stderr='', stdout='') ->
+      if code is 0
+        callback()
       else
-        switch process.platform
-          when 'darwin'
-            child_process.exec 'mdfind "kMDItemCFBundleIdentifier == \'com.github.atom\'"', (error, stdout='', stderr) ->
-              appLocation = stdout.split('\n')[0] ? '/Applications/Atom.app'
-              callback("#{appLocation}/Contents/Resources/app")
-          when 'linux'
-            process.nextTick -> callback('/usr/local/share/atom/resources/app')
-          when 'win32'
-            process.nextTick =>
-              programFilesPath = path.join(process.env.ProgramFiles, 'Atom', 'resources', 'app')
-
-              # Scan for latest chocolatey install version when not in program files
-              unless fs.isDirectorySync(programFilesPath)
-                if process.env.CHOCOLATEYINSTALL
-                  chocolateyLibPath = path.join(process.env.CHOCOLATEYINSTALL, 'lib')
-
-                if process.env.ALLUSERSPROFILE and not fs.isDirectorySync(chocolateyLibPath)
-                  chocolateyLibPath = path.join(process.env.ALLUSERSPROFILE, 'chocolatey', 'lib')
-
-                latestVersion = null
-                for child in fs.list(chocolateyLibPath)
-                  if child.indexOf('Atom.') is 0
-                    version = child.substring(5)
-                    if semver.valid(version)
-                      latestVersion ?= version
-                      latestVersion = version if semver.gt(version, latestVersion)
-
-                if latestVersion
-                  appLocation = path.join(chocolateyLibPath, "Atom.#{version}", 'tools', 'Atom', 'resources', 'app')
-                  return callback(appLocation) if fs.isDirectorySync(appLocation)
-
-              callback(programFilesPath)
-
-  getReposDirectory: ->
-    process.env.ATOM_REPOS_HOME ? path.join(@getHomeDirectory(), 'github')
-
-  getNodeUrl: ->
-    process.env.ATOM_NODE_URL ? 'https://gh-contractor-zcbenz.s3.amazonaws.com/atom-shell/dist'
-
-  getAtomPackagesUrl: ->
-    process.env.ATOM_PACKAGES_URL ? "#{@getAtomApiUrl()}/packages"
-
-  getAtomApiUrl: ->
-    process.env.ATOM_API_URL ? 'https://atom.io/api'
-
-  getNodeVersion: ->
-    process.env.ATOM_NODE_VERSION ? '0.20.0'
-
-  getNodeArch: ->
-    switch process.platform
-      when 'darwin' then 'x64'
-      when 'win32' then 'ia32'
-      else process.arch  # On BSD and Linux we use current machine's arch.
-
-  getUserConfigPath: ->
-    path.resolve(@getAtomDirectory(), '.apmrc')
-
-  getGlobalConfigPath: ->
-    path.resolve(__dirname, '..', '.apmrc')
-
-  isWin32: ->
-    process.platform is 'win32'
-
-  isWindows64Bit: ->
-    fs.existsSync "C:\\Windows\\SysWow64\\Notepad.exe"
-
-  x86ProgramFilesDirectory: ->
-    process.env["ProgramFiles(x86)"] or process.env["ProgramFiles"]
-
-  getInstalledVisualStudioFlag: ->
-    return null unless @isWin32()
-
-    # Use the explictly-configured version when set
-    return process.env.GYP_MSVS_VERSION if process.env.GYP_MSVS_VERSION
-
-    vs2013Path = path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio 12.0", "Common7", "IDE")
-    return '2013' if fs.existsSync(vs2013Path)
-
-    vs2012Path = path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio 11.0", "Common7", "IDE")
-    return '2012' if fs.existsSync(vs2012Path)
-
-    vs2010Path = path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio 10.0", "Common7", "IDE")
-    return '2010' if fs.existsSync(vs2010Path)
-
-  loadNpm: (callback) ->
-    npmOptions =
-      userconfig: @getUserConfigPath()
-      globalconfig: @getGlobalConfigPath()
-    npm.load npmOptions, -> callback(null, npm)
-
-  getSetting: (key, callback) ->
-    @loadNpm -> callback(npm.config.get(key))
-
-  getChocolateyAtomPath: ->
-    if process.env.CHOCOLATEYINSTALL
-      atomCommand = path.join(process.env.CHOCOLATEYINSTALL, 'bin', 'atom.exe')
-      return atomCommand if fs.existsSync(atomCommand)
-
-    if process.env.ALLUSERSPROFILE
-      atomCommand = path.join(process.env.ALLUSERSPROFILE, 'chocolatey', 'bin', 'atom.exe')
-      return atomCommand if fs.existsSync(atomCommand)
-
-    null
+        callback(new Error("npm config failed: #{code}"))

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -34,10 +34,12 @@ class Config extends Command
     configArgs = configArgs.concat(options.argv._)
 
     env = _.extend({}, process.env, HOME: @atomNodeDirectory)
-    configOptions = {env, streaming: true}
+    configOptions = {env}
 
     @fork @atomNpmPath, configArgs, configOptions, (code, stderr='', stdout='') ->
       if code is 0
+        process.stdout.write(stdout) if stdout
         callback()
       else
+        process.stdout.write(stderr) if stderr
         callback(new Error("npm config failed: #{code}"))

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -4,7 +4,7 @@ async = require 'async'
 _ = require 'underscore-plus'
 optimist = require 'optimist'
 
-config = require './config'
+config = require './apm'
 Command = require './command'
 fs = require './fs'
 

--- a/src/develop.coffee
+++ b/src/develop.coffee
@@ -4,7 +4,7 @@ path = require 'path'
 _ = require 'underscore-plus'
 optimist = require 'optimist'
 
-config = require './config'
+config = require './apm'
 Command = require './command'
 Install = require './install'
 Link = require './link'

--- a/src/docs.coffee
+++ b/src/docs.coffee
@@ -2,7 +2,7 @@ optimist = require 'optimist'
 open = require 'open'
 
 View = require './view'
-config = require './config'
+config = require './apm'
 
 module.exports =
 class Docs extends View

--- a/src/featured.coffee
+++ b/src/featured.coffee
@@ -2,7 +2,7 @@ _ = require 'underscore-plus'
 optimist = require 'optimist'
 
 Command = require './command'
-config = require './config'
+config = require './apm'
 request = require './request'
 tree = require './tree'
 

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -7,7 +7,7 @@ CSON = require 'season'
 semver = require 'npm/node_modules/semver'
 temp = require 'temp'
 
-config = require './config'
+config = require './apm'
 Command = require './command'
 fs = require './fs'
 RebuildModuleCache = require './rebuild-module-cache'

--- a/src/link.coffee
+++ b/src/link.coffee
@@ -4,7 +4,7 @@ CSON = require 'season'
 optimist = require 'optimist'
 
 Command = require './command'
-config = require './config'
+config = require './apm'
 fs = require './fs'
 
 module.exports =

--- a/src/links.coffee
+++ b/src/links.coffee
@@ -3,7 +3,7 @@ path = require 'path'
 optimist = require 'optimist'
 
 Command = require './command'
-config = require './config'
+config = require './apm'
 fs = require './fs'
 tree = require './tree'
 

--- a/src/list.coffee
+++ b/src/list.coffee
@@ -6,7 +6,7 @@ optimist = require 'optimist'
 
 Command = require './command'
 fs = require './fs'
-config = require './config'
+config = require './apm'
 tree = require './tree'
 
 module.exports =

--- a/src/publish.coffee
+++ b/src/publish.coffee
@@ -4,7 +4,7 @@ optimist = require 'optimist'
 Git = require 'git-utils'
 
 fs = require './fs'
-config = require './config'
+config = require './apm'
 Command = require './command'
 Login = require './login'
 Packages = require './packages'

--- a/src/rebuild-module-cache.coffee
+++ b/src/rebuild-module-cache.coffee
@@ -2,7 +2,7 @@ path = require 'path'
 async = require 'async'
 optimist = require 'optimist'
 Command = require './command'
-config = require './config'
+config = require './apm'
 fs = require './fs'
 
 module.exports =

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -3,7 +3,7 @@ path = require 'path'
 _ = require 'underscore-plus'
 optimist = require 'optimist'
 
-config = require './config'
+config = require './apm'
 Command = require './command'
 Install = require './install'
 

--- a/src/request.coffee
+++ b/src/request.coffee
@@ -1,7 +1,7 @@
 npm = require 'npm'
 request = require 'npm/node_modules/request'
 
-config = require './config'
+config = require './apm'
 
 loadNpm = (callback) ->
   npmOptions =

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -2,7 +2,7 @@ _ = require 'underscore-plus'
 optimist = require 'optimist'
 
 Command = require './command'
-config = require './config'
+config = require './apm'
 request = require './request'
 tree = require './tree'
 

--- a/src/star.coffee
+++ b/src/star.coffee
@@ -5,7 +5,7 @@ async = require 'async'
 CSON = require 'season'
 optimist = require 'optimist'
 
-config = require './config'
+config = require './apm'
 Command = require './command'
 fs = require './fs'
 Login = require './login'

--- a/src/stars.coffee
+++ b/src/stars.coffee
@@ -2,7 +2,7 @@ _ = require 'underscore-plus'
 optimist = require 'optimist'
 
 Command = require './command'
-config = require './config'
+config = require './apm'
 Install = require './install'
 Login = require './login'
 request = require './request'

--- a/src/uninstall.coffee
+++ b/src/uninstall.coffee
@@ -6,7 +6,7 @@ optimist = require 'optimist'
 
 auth = require './auth'
 Command = require './command'
-config = require './config'
+config = require './apm'
 fs = require './fs'
 request = require './request'
 

--- a/src/unlink.coffee
+++ b/src/unlink.coffee
@@ -4,7 +4,7 @@ CSON = require 'season'
 optimist = require 'optimist'
 
 Command = require './command'
-config = require './config'
+config = require './apm'
 fs = require './fs'
 
 module.exports =

--- a/src/unpublish.coffee
+++ b/src/unpublish.coffee
@@ -5,7 +5,7 @@ optimist = require 'optimist'
 
 auth = require './auth'
 Command = require './command'
-config = require './config'
+config = require './apm'
 fs = require './fs'
 request = require './request'
 

--- a/src/unstar.coffee
+++ b/src/unstar.coffee
@@ -1,7 +1,7 @@
 async = require 'async'
 optimist = require 'optimist'
 
-config = require './config'
+config = require './apm'
 Command = require './command'
 Login = require './login'
 request = require './request'

--- a/src/upgrade.coffee
+++ b/src/upgrade.coffee
@@ -7,7 +7,7 @@ read = require 'read'
 semver = require 'npm/node_modules/semver'
 
 Command = require './command'
-config = require './config'
+config = require './apm'
 fs = require './fs'
 Install = require './install'
 Packages = require './packages'

--- a/src/view.coffee
+++ b/src/view.coffee
@@ -2,7 +2,7 @@ _ = require 'underscore-plus'
 optimist = require 'optimist'
 
 Command = require './command'
-config = require './config'
+config = require './apm'
 request = require './request'
 tree = require './tree'
 


### PR DESCRIPTION
This is essentially just a pass through to `npm config` but it makes configuring apm from the command line much easier.

For example:

```
> apm config set proxy http://9.0.2.1.0

> apm config list
; cli configs
globalconfig = "/Users/kevin/github/apm/.apmrc"
user-agent = "npm/2.1.18 node/v0.10.35 darwin x64"
userconfig = "/Users/kevin/.atom/.apmrc"

; userconfig /Users/kevin/.atom/.apmrc
proxy = "http://9.0.2.1.0/"

; globalconfig /Users/kevin/github/apm/.apmrc
cache = "/Users/kevin/.atom/.node-gyp/.atom/.apm"

; node bin location = /Users/kevin/github/apm/bin/node
; cwd = /Users/kevin/github/apm
; HOME = /Users/kevin/.atom/.node-gyp
; 'npm config ls -l' to show all defaults.
```