### PR TITLE
Shadow-DOM-ify the template syntax theme.

### DIFF
--- a/templates/theme/styles/base.less
+++ b/templates/theme/styles/base.less
@@ -305,6 +305,7 @@ atom-text-editor .search-results .marker.current-result .region,
   }
 }
 
-:host(.mini) .scroll-view {
+atom-text-editor[mini] .scroll-view,
+:host([mini]) .scroll-view {
   padding-left: 1px;
 }

--- a/templates/theme/styles/base.less
+++ b/templates/theme/styles/base.less
@@ -1,6 +1,6 @@
 @import "syntax-variables";
 
-:host {
+atom-text-editor, :host {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
@@ -51,11 +51,13 @@
   }
 }
 
+atom-text-editor .search-results .marker .region,
 :host .search-results .marker .region {
   background-color: transparent;
   border: 1px solid @syntax-result-marker-color;
 }
 
+atom-text-editor .search-results .marker.current-result .region,
 :host .search-results .marker.current-result .region {
   border: 1px solid @syntax-result-marker-color-selected;
 }

--- a/templates/theme/styles/base.less
+++ b/templates/theme/styles/base.less
@@ -1,11 +1,6 @@
 @import "syntax-variables";
 
-.editor-colors {
-  background-color: @syntax-background-color;
-  color: @syntax-text-color;
-}
-
-.editor {
+:host {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
@@ -56,12 +51,12 @@
   }
 }
 
-.editor .search-results .marker .region {
+:host .search-results .marker .region {
   background-color: transparent;
   border: 1px solid @syntax-result-marker-color;
 }
 
-.editor .search-results .marker.current-result .region {
+:host .search-results .marker.current-result .region {
   border: 1px solid @syntax-result-marker-color-selected;
 }
 
@@ -308,6 +303,6 @@
   }
 }
 
-.editor.mini .scroll-view {
+:host(.mini) .scroll-view {
   padding-left: 1px;
 }


### PR DESCRIPTION
This *removes* the old-style selectors, which means that (without explicit
retrofitting) themes based off of this template will *not* work with
shadow DOM disabled (or on earlier versions of Atom that don't use the
shadow DOM facility).

- - - - -
[PR-only comment]

I didn't find any instructions in the repo for how to build and test `apm`, so I was unable to test this per se. However, near as I could tell from installing this file as part of a syntax theme, it works as expected.