### PR TITLE
Add --packages flag to apm list

### DIFF
--- a/src/list.coffee
+++ b/src/list.coffee
@@ -27,6 +27,7 @@ class List extends Command
 
       Usage: apm list
              apm list --themes
+             apm list --packages
              apm list --installed
              apm list --installed --bare > my-packages.txt
              apm list --json
@@ -38,6 +39,7 @@ class List extends Command
     options.alias('i', 'installed').boolean('installed').describe('installed', 'Only list installed packages/themes')
     options.alias('j', 'json').boolean('json').describe('json',  'Output all packages as a JSON object')
     options.alias('t', 'themes').boolean('themes').describe('themes', 'Only list themes')
+    options.alias('p', 'packages').boolean('packages').describe('packages', 'Only list packages')
 
   isPackageDisabled: (name) ->
     @disabledPackages.indexOf(name) isnt -1
@@ -69,6 +71,8 @@ class List extends Command
       manifest.name = child
       if options.argv.themes
         packages.push(manifest) if manifest.theme
+      else if options.argv.packages
+        packages.push(manifest) if not manifest.theme
       else
         packages.push(manifest)
 

--- a/src/list.coffee
+++ b/src/list.coffee
@@ -72,7 +72,7 @@ class List extends Command
       if options.argv.themes
         packages.push(manifest) if manifest.theme
       else if options.argv.packages
-        packages.push(manifest) if not manifest.theme
+        packages.push(manifest) unless manifest.theme
       else
         packages.push(manifest)
 

--- a/src/list.coffee
+++ b/src/list.coffee
@@ -37,7 +37,7 @@ class List extends Command
     options.alias('b', 'bare').boolean('bare').describe('bare', 'Print packages one per line with no formatting')
     options.alias('h', 'help').describe('help', 'Print this usage message')
     options.alias('i', 'installed').boolean('installed').describe('installed', 'Only list installed packages/themes')
-    options.alias('j', 'json').boolean('json').describe('json',  'Output all packages as a JSON object')
+    options.alias('j', 'json').boolean('json').describe('json', 'Output all packages as a JSON object')
     options.alias('t', 'themes').boolean('themes').describe('themes', 'Only list themes')
     options.alias('p', 'packages').boolean('packages').describe('packages', 'Only list packages')
 


### PR DESCRIPTION
This implements my enhancement suggestion in #256 – it adds a `--packages` (or `-p`) flag for only listing packages. If combined with `--themes`, it'll just list everything, which seems fine to me.

Should I add a test for this? I noticed there aren't any tests for any of the flags, so I wasn't sure. (Maybe there should be?)

Either way, let me know! :smiley: 

(Resolves #256)