### PR TITLE
Better Git error

### DIFF
--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -9,6 +9,7 @@ wordwrap = require 'wordwrap'
 
 config = require './apm'
 fs = require './fs'
+git = require './git'
 
 setupTempDirectory = ->
   temp = require 'temp'
@@ -83,7 +84,7 @@ printVersions = (args, callback) ->
   nodeVersion = process.versions.node ? ''
 
   getPythonVersion (pythonVersion) ->
-    getGitVersion (gitVersion) ->
+    git.getGitVersion (gitVersion) ->
       if args.json
         versions =
           apm: apmVersion
@@ -134,23 +135,6 @@ getPythonVersion = (callback) ->
     spawned.on 'close', (code) ->
       if code is 0
         [name, version] = Buffer.concat(outputChunks).toString().split(' ')
-        version = version?.trim()
-      callback(version)
-
-getGitVersion = (callback) ->
-  npmOptions =
-    userconfig: config.getUserConfigPath()
-    globalconfig: config.getGlobalConfigPath()
-  npm.load npmOptions, ->
-    git = npm.config.get('git') ? 'git'
-    spawned = spawn(git, ['--version'])
-    outputChunks = []
-    spawned.stderr.on 'data', (chunk) -> outputChunks.push(chunk)
-    spawned.stdout.on 'data', (chunk) -> outputChunks.push(chunk)
-    spawned.on 'error', ->
-    spawned.on 'close', (code) ->
-      if code is 0
-        [gitName, versionName, version] = Buffer.concat(outputChunks).toString().split(' ')
         version = version?.trim()
       callback(version)
 

--- a/src/develop.coffee
+++ b/src/develop.coffee
@@ -7,6 +7,7 @@ optimist = require 'optimist'
 config = require './apm'
 Command = require './command'
 Install = require './install'
+git = require './git'
 Link = require './link'
 request = require './request'
 
@@ -55,9 +56,10 @@ class Develop extends Command
 
   cloneRepository: (repoUrl, packageDirectory, options) ->
     config.getSetting 'git', (command) =>
-      command ?= "git"
+      command ?= 'git'
       args = ['clone', '--recursive', repoUrl, packageDirectory]
       process.stdout.write "Cloning #{repoUrl} "
+      git.addGitToEnv(process.env)
       @spawn command, args, (code, stderr='', stdout='') =>
         if code is 0
           @logSuccess()

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -1,4 +1,5 @@
 {spawn} = require 'child_process'
+path = require 'path'
 _ = require 'underscore-plus'
 npm = require 'npm'
 config = require './apm'

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -10,7 +10,7 @@ addPortableGitToEnv = (env) ->
   return unless localAppData
 
   try
-    children = fs.listSync(path.join(localAppData, 'GitHub'))
+    children = fs.readdirSync(path.join(localAppData, 'GitHub'))
   catch error
     return
 

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -1,0 +1,65 @@
+{spawn} = require 'child_process'
+_ = require 'underscore-plus'
+npm = require 'npm'
+config = require './apm'
+fs = require './fs'
+
+addPortableGitToEnv = (env) ->
+  localAppData = env.LocalAppData
+  return unless localAppData
+
+  try
+    children = fs.listSync(path.join(localAppData, 'GitHub'))
+  catch error
+    return
+
+  for child in children when child.indexOf('PortableGit_') is 0
+    cmdPath = path.join(localAppData, 'GitHub', child, 'cmd')
+    binPath = path.join(localAppData, 'GitHub', child, 'bin')
+    if env.Path
+      env.Path += "#{path.delimiter}#{cmdPath}#{path.delimiter}#{binPath}"
+    else
+      env.Path = "#{cmdPath}#{path.delimiter}#{binPath}"
+    break
+
+  return
+
+addGitBashToEnv = (env) ->
+  if env.ProgramFiles
+    gitPath = path.join(env.ProgramFiles, 'Git')
+
+  unless fs.isDirectorySync(gitPath)
+    if env['ProgramFiles(x86)']
+      gitPath = path.join(env['ProgramFiles(x86)'], 'Git')
+
+  return unless fs.isDirectorySync(gitPath)
+
+  cmdPath = path.join(gitPath, 'cmd')
+  binPath = path.join(gitPath, 'bin')
+  if env.Path
+    env.Path += "#{path.delimiter}#{cmdPath}#{path.delimiter}#{binPath}"
+  else
+    env.Path = "#{cmdPath}#{path.delimiter}#{binPath}"
+
+exports.addGitToEnv = (env) ->
+  addPortableGitToEnv(env)
+  addGitBashToEnv(env)
+
+exports.getGitVersion = (callback) ->
+  npmOptions =
+    userconfig: config.getUserConfigPath()
+    globalconfig: config.getGlobalConfigPath()
+  npm.load npmOptions, ->
+    git = npm.config.get('git') ? 'git'
+    env = _.extend({}, process.env)
+    exports.addGitToEnv(env) if process.platform is 'win32'
+    spawned = spawn(git, ['--version'], {env})
+    outputChunks = []
+    spawned.stderr.on 'data', (chunk) -> outputChunks.push(chunk)
+    spawned.stdout.on 'data', (chunk) -> outputChunks.push(chunk)
+    spawned.on 'error', ->
+    spawned.on 'close', (code) ->
+      if code is 0
+        [gitName, versionName, version] = Buffer.concat(outputChunks).toString().split(' ')
+        version = version?.trim()
+      callback(version)

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -52,9 +52,8 @@ exports.getGitVersion = (callback) ->
     globalconfig: config.getGlobalConfigPath()
   npm.load npmOptions, ->
     git = npm.config.get('git') ? 'git'
-    env = _.extend({}, process.env)
-    exports.addGitToEnv(env) if process.platform is 'win32'
-    spawned = spawn(git, ['--version'], {env})
+    exports.addGitToEnv(process.env) if process.platform is 'win32'
+    spawned = spawn(git, ['--version'])
     outputChunks = []
     spawned.stderr.on 'data', (chunk) -> outputChunks.push(chunk)
     spawned.stdout.on 'data', (chunk) -> outputChunks.push(chunk)

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -43,6 +43,7 @@ addGitBashToEnv = (env) ->
     env.Path = "#{cmdPath}#{path.delimiter}#{binPath}"
 
 exports.addGitToEnv = (env) ->
+  return if process.platform isnt 'win32'
   addPortableGitToEnv(env)
   addGitBashToEnv(env)
 
@@ -52,7 +53,7 @@ exports.getGitVersion = (callback) ->
     globalconfig: config.getGlobalConfigPath()
   npm.load npmOptions, ->
     git = npm.config.get('git') ? 'git'
-    exports.addGitToEnv(process.env) if process.platform is 'win32'
+    exports.addGitToEnv(process.env)
     spawned = spawn(git, ['--version'])
     outputChunks = []
     spawned.stderr.on 'data', (chunk) -> outputChunks.push(chunk)

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -9,14 +9,16 @@ addPortableGitToEnv = (env) ->
   localAppData = env.LOCALAPPDATA
   return unless localAppData
 
+  githubPath = path.join(localAppData, 'GitHub')
+
   try
-    children = fs.readdirSync(path.join(localAppData, 'GitHub'))
+    children = fs.readdirSync(githubPath)
   catch error
     return
 
   for child in children when child.indexOf('PortableGit_') is 0
-    cmdPath = path.join(localAppData, 'GitHub', child, 'cmd')
-    binPath = path.join(localAppData, 'GitHub', child, 'bin')
+    cmdPath = path.join(githubPath, child, 'cmd')
+    binPath = path.join(githubPath, child, 'bin')
     if env.Path
       env.Path += "#{path.delimiter}#{cmdPath}#{path.delimiter}#{binPath}"
     else

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -6,7 +6,7 @@ config = require './apm'
 fs = require './fs'
 
 addPortableGitToEnv = (env) ->
-  localAppData = env.LocalAppData
+  localAppData = env.LOCALAPPDATA
   return unless localAppData
 
   try

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -177,6 +177,7 @@ class Install extends Command
       The #{pack.name} package has module dependencies that cannot be installed without Git.
 
       You need install Git and make it available on your path environment variable in order to install this package.
+
     """
 
     switch process.platform
@@ -184,11 +185,13 @@ class Install extends Command
         message += """
 
           You can install Git by downloading and installing GitHub for Windows: https://windows.github.com
+
         """
       when 'linux'
         message += """
 
           You can install Git from your OS package manager.
+
         """
 
     message += """

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -92,7 +92,7 @@ class Install extends Command
     else
       env.Path = localModuleBins
 
-    addGitToEnv(env)
+    @addGitToEnv(env)
 
   addNodeBinToEnv: (env) ->
     nodeBinFolder = path.resolve(__dirname, '..', 'bin')

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -184,7 +184,7 @@ class Install extends Command
       when 'win32'
         message += """
 
-          You can install Git by downloading and installing GitHub for Windows: https://windows.github.com
+          You can install Git by downloading, installing, and launching GitHub for Windows: https://windows.github.com
 
         """
       when 'linux'

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -166,33 +166,38 @@ class Install extends Command
           fs.removeSync(installDirectory)
           @logFailure()
 
-        output = "#{stdout}\n#{stderr}"
-        if output.indexOf('code ENOGIT') isnt -1
-          output = """
-            Failed to install #{pack.name} because Git was not found.
-
-            The #{pack.name} package has module dependencies that cannot be installed without Git.
-
-            You need install Git and make it available on your path environment variable in order to install this package.
-          """
-          switch process.platform
-            when 'win32'
-              output += """
-
-                You can install Git by downloading and installing GitHub for Windows: https://windows.github.com
-              """
-            when 'linux'
-              output += """
-
-                You can install Git from your OS package manager.
-              """
-
-          output += """
-
-            Run apm -v after installing Git to see what version has been detected.
-          """
+        error = "#{stdout}\n#{stderr}"
+        error = @getGitErrorMessage() if error.indexOf('code ENOGIT') isnt -1
 
         callback(output)
+
+  getGitErrorMessage: ->
+    message = """
+      Failed to install #{pack.name} because Git was not found.
+
+      The #{pack.name} package has module dependencies that cannot be installed without Git.
+
+      You need install Git and make it available on your path environment variable in order to install this package.
+    """
+
+    switch process.platform
+      when 'win32'
+        message += """
+
+          You can install Git by downloading and installing GitHub for Windows: https://windows.github.com
+        """
+      when 'linux'
+        message += """
+
+          You can install Git from your OS package manager.
+        """
+
+    message += """
+
+      Run apm -v after installing Git to see what version has been detected.
+    """
+
+    message
 
   getVisualStudioFlags: ->
     if vsVersion = config.getInstalledVisualStudioFlag()

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -168,10 +168,11 @@ class Install extends Command
 
         output = "#{stdout}\n#{stderr}"
         if output.indexOf('code ENOGIT') isnt -1
-          output = """"
+          output = """
             Failed to install #{pack.name} because Git was not found.
 
             The #{pack.name} package has module dependencies that require Git to be installed.
+
             You need install Git and make it available on your PATH environment variable in order
             to install this package.
           """
@@ -179,8 +180,7 @@ class Install extends Command
             when 'win32'
               output += """
 
-                You can install Git by downloading and installing GitHub for Windows.
-                https://windows.github.com
+                You can install Git by downloading and installing GitHub for Windows: https://windows.github.com
               """
             when 'linux'
               output += """

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -114,6 +114,10 @@ class Install extends Command
       env.https_proxy ?= httpsProxy
 
   addGitToEnv: (env) ->
+    @addPortableGitToEnv(env)
+    @addGitBashToEnv(env)
+
+  addPortableGitToEnv: ->
     localAppData = env.LocalAppData
     return unless localAppData
 
@@ -132,6 +136,23 @@ class Install extends Command
       break
 
     return
+
+  addGitBashToEnv: (env) ->
+    if process.env.ProgramFiles
+      gitPath = path.join(process.env.ProgramFiles, 'Git')
+
+    unless fs.isDirectorySync(gitPath)
+      if process.env['ProgramFiles(x86)']
+        gitPath = path.join(process.env['ProgramFiles(x86)'], 'Git')
+
+    return unless fs.isDirectorySync(gitPath)
+
+    cmdPath = path.join(gitPath, 'cmd')
+    binPath = path.join(gitPath, 'bin')
+    if env.Path
+      env.Path += "#{path.delimiter}#{cmdPath}#{path.delimiter}#{binPath}"
+    else
+      env.Path = "#{cmdPath}#{path.delimiter}#{binPath}"
 
   installModule: (options, pack, modulePath, callback) ->
     installArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'install']

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -168,8 +168,7 @@ class Install extends Command
 
         error = "#{stdout}\n#{stderr}"
         error = @getGitErrorMessage(pack) if error.indexOf('code ENOGIT') isnt -1
-
-        callback(output)
+        callback(error)
 
   getGitErrorMessage: (pack) ->
     message = """

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -10,6 +10,7 @@ temp = require 'temp'
 config = require './apm'
 Command = require './command'
 fs = require './fs'
+git = require './git'
 RebuildModuleCache = require './rebuild-module-cache'
 request = require './request'
 
@@ -92,7 +93,7 @@ class Install extends Command
     else
       env.Path = localModuleBins
 
-    @addGitToEnv(env)
+    git.addGitToEnv(env)
 
   addNodeBinToEnv: (env) ->
     nodeBinFolder = path.resolve(__dirname, '..', 'bin')
@@ -112,47 +113,6 @@ class Install extends Command
     if httpsProxy
       env.HTTPS_PROXY ?= httpsProxy
       env.https_proxy ?= httpsProxy
-
-  addGitToEnv: (env) ->
-    @addPortableGitToEnv(env)
-    @addGitBashToEnv(env)
-
-  addPortableGitToEnv: (env) ->
-    localAppData = env.LocalAppData
-    return unless localAppData
-
-    try
-      children = fs.listSync(path.join(localAppData, 'GitHub'))
-    catch error
-      return
-
-    for child in children when child.indexOf('PortableGit_') is 0
-      cmdPath = path.join(localAppData, 'GitHub', child, 'cmd')
-      binPath = path.join(localAppData, 'GitHub', child, 'bin')
-      if env.Path
-        env.Path += "#{path.delimiter}#{cmdPath}#{path.delimiter}#{binPath}"
-      else
-        env.Path = "#{cmdPath}#{path.delimiter}#{binPath}"
-      break
-
-    return
-
-  addGitBashToEnv: (env) ->
-    if env.ProgramFiles
-      gitPath = path.join(env.ProgramFiles, 'Git')
-
-    unless fs.isDirectorySync(gitPath)
-      if env['ProgramFiles(x86)']
-        gitPath = path.join(env['ProgramFiles(x86)'], 'Git')
-
-    return unless fs.isDirectorySync(gitPath)
-
-    cmdPath = path.join(gitPath, 'cmd')
-    binPath = path.join(gitPath, 'bin')
-    if env.Path
-      env.Path += "#{path.delimiter}#{cmdPath}#{path.delimiter}#{binPath}"
-    else
-      env.Path = "#{cmdPath}#{path.delimiter}#{binPath}"
 
   installModule: (options, pack, modulePath, callback) ->
     installArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'install']

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -171,7 +171,7 @@ class Install extends Command
           output = """
             Failed to install #{pack.name} because Git was not found.
 
-            The #{pack.name} package has module dependencies that require Git to be installed.
+            The #{pack.name} package has module dependencies that cannot be installed without Git.
 
             You need install Git and make it available on your PATH environment variable in order to install this package.
           """

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -185,7 +185,29 @@ class Install extends Command
           fs.removeSync(installDirectory)
           @logFailure()
 
-        callback("#{stdout}\n#{stderr}")
+        output = "#{stdout}\n#{stderr}"
+        if output.indexOf('code ENOGIT') isnt -1
+          output = """"
+            Failed to install #{pack.name} because Git was not found.
+
+            The #{pack.name} package has module dependencies that require Git to be installed.
+            You need install Git and make it available on your PATH environment variable in order
+            to install this package.
+          """
+          switch process.platform
+            when 'win32'
+              output += """
+
+                You can install Git by downloading and installing GitHub for Windows.
+                https://windows.github.com
+              """
+            when 'linux'
+              output += """
+
+                You can install Git from your distributions's package manager.
+              """
+
+        callback(output)
 
   getVisualStudioFlags: ->
     if vsVersion = config.getInstalledVisualStudioFlag()

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -173,7 +173,7 @@ class Install extends Command
 
             The #{pack.name} package has module dependencies that cannot be installed without Git.
 
-            You need install Git and make it available on your PATH environment variable in order to install this package.
+            You need install Git and make it available on your path environment variable in order to install this package.
           """
           switch process.platform
             when 'win32'
@@ -186,6 +186,11 @@ class Install extends Command
 
                 You can install Git from your OS package manager.
               """
+
+          output += """
+
+            Run apm -v after installing Git to see what version has been detected.
+          """
 
         callback(output)
 

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -176,7 +176,7 @@ class Install extends Command
 
       The #{pack.name} package has module dependencies that cannot be installed without Git.
 
-      You need install Git and make it available on your path environment variable in order to install this package.
+      You need to install Git and add it to your path environment variable in order to install this package.
 
     """
 

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -117,7 +117,7 @@ class Install extends Command
     @addPortableGitToEnv(env)
     @addGitBashToEnv(env)
 
-  addPortableGitToEnv: ->
+  addPortableGitToEnv: (env) ->
     localAppData = env.LocalAppData
     return unless localAppData
 

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -92,6 +92,8 @@ class Install extends Command
     else
       env.Path = localModuleBins
 
+    addGitToEnv(env)
+
   addNodeBinToEnv: (env) ->
     nodeBinFolder = path.resolve(__dirname, '..', 'bin')
     pathKey = if config.isWin32() then 'Path' else 'PATH'
@@ -110,6 +112,26 @@ class Install extends Command
     if httpsProxy
       env.HTTPS_PROXY ?= httpsProxy
       env.https_proxy ?= httpsProxy
+
+  addGitToEnv: (env) ->
+    localAppData = env.LocalAppData
+    return unless localAppData
+
+    try
+      children = fs.listSync(path.join(localAppData, 'GitHub'))
+    catch error
+      return
+
+    for child in children when child.indexOf('PortableGit_') is 0
+      cmdPath = path.join(localAppData, 'GitHub', child, 'cmd')
+      binPath = path.join(localAppData, 'GitHub', child, 'bin')
+      if env.Path
+        env.Path += "#{path.delimiter}#{cmdPath}#{path.delimiter}#{binPath}"
+      else
+        env.Path = "#{cmdPath}#{path.delimiter}#{binPath}"
+      break
+
+    return
 
   installModule: (options, pack, modulePath, callback) ->
     installArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'install']

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -167,11 +167,11 @@ class Install extends Command
           @logFailure()
 
         error = "#{stdout}\n#{stderr}"
-        error = @getGitErrorMessage() if error.indexOf('code ENOGIT') isnt -1
+        error = @getGitErrorMessage(pack) if error.indexOf('code ENOGIT') isnt -1
 
         callback(output)
 
-  getGitErrorMessage: ->
+  getGitErrorMessage: (pack) ->
     message = """
       Failed to install #{pack.name} because Git was not found.
 

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -173,8 +173,7 @@ class Install extends Command
 
             The #{pack.name} package has module dependencies that require Git to be installed.
 
-            You need install Git and make it available on your PATH environment variable in order
-            to install this package.
+            You need install Git and make it available on your PATH environment variable in order to install this package.
           """
           switch process.platform
             when 'win32'
@@ -185,7 +184,7 @@ class Install extends Command
             when 'linux'
               output += """
 
-                You can install Git from your distributions's package manager.
+                You can install Git from your OS package manager.
               """
 
         callback(output)

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -138,12 +138,12 @@ class Install extends Command
     return
 
   addGitBashToEnv: (env) ->
-    if process.env.ProgramFiles
-      gitPath = path.join(process.env.ProgramFiles, 'Git')
+    if env.ProgramFiles
+      gitPath = path.join(env.ProgramFiles, 'Git')
 
     unless fs.isDirectorySync(gitPath)
-      if process.env['ProgramFiles(x86)']
-        gitPath = path.join(process.env['ProgramFiles(x86)'], 'Git')
+      if env['ProgramFiles(x86)']
+        gitPath = path.join(env['ProgramFiles(x86)'], 'Git')
 
     return unless fs.isDirectorySync(gitPath)
 


### PR DESCRIPTION
This PR does two things:

* Show a friendlier message when install fails because a package requires Git and Git isn't installed.  This replaces the preview giant error from npm with a little `ENOGIT` message somewhere in there.

* Put the install locations for GitHub for Windows and Git Bash on the path automatically. These aren't on the path automatically since each app includes a custom shell.

Closes https://github.com/atom/atom/issues/5193