### PR TITLE
Respect ATOM_HOME in cache path

### DIFF
--- a/.apmrc
+++ b/.apmrc
@@ -1,1 +1,0 @@
-cache = ~/.atom/.apm

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ lib/
 .DS_Store
 npm-debug.log
 *~
+/.apmrc

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ tasks/
 bin/node
 .travis.yml
 .pairs
+/.apmrc

--- a/.npmignore
+++ b/.npmignore
@@ -7,4 +7,3 @@ tasks/
 bin/node
 .travis.yml
 .pairs
-/.apmrc

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -37,7 +37,10 @@ module.exports = (grunt) ->
     grunt.file.delete('lib') if grunt.file.exists('lib')
     grunt.file.delete('bin/node_darwin_x64') if grunt.file.exists('bin/node_darwin_x64')
 
+  grunt.registerTask 'generate-apmrc', ->
+    grunt.file.write('.apmrc', 'cache = ~/.atom/.apm\n')
+
   grunt.registerTask('lint', ['coffeelint'])
   grunt.registerTask('default', ['coffee', 'lint'])
   grunt.registerTask('test', ['clean', 'default', 'shell:test'])
-  grunt.registerTask('prepublish', ['clean', 'coffee', 'lint'])
+  grunt.registerTask('prepublish', ['clean', 'coffee', 'lint', 'generate-apmrc'])

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -18,7 +18,7 @@ describe "apm config", ->
     delete process.env.npm_config_cache
 
   describe "apm config get", ->
-    it "reads the value from the global config where there is no user config", ->
+    it "reads the value from the global config when there is no user config", ->
       callback = jasmine.createSpy('callback')
       apm.run(['config', 'get', 'cache'], callback)
 
@@ -26,7 +26,7 @@ describe "apm config", ->
         callback.callCount is 1
 
       runs ->
-        expect(process.stdout.write.argsForCall[0][0].trim()).toBe path.join(process.env.ATOM_HOME, '.node-gyp', '.atom', '.apm')
+        expect(process.stdout.write.argsForCall[0][0].trim()).toBe path.join(process.env.ATOM_HOME, '.apm')
 
   describe "apm config set", ->
     it "sets the value in the user config", ->

--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -99,7 +99,7 @@ describe 'apm install', ->
 
       describe "when the package is already in the cache", ->
         it "installs it from the cache", ->
-          cachePath = path.join(require('../lib/apm').getPackageCacheDirectory(), 'test-module2', '2.0.0', 'package.tgz')
+          cachePath = path.join(require('../lib/apm').getCacheDirectory(), 'test-module2', '2.0.0', 'package.tgz')
           testModuleDirectory = path.join(atomHome, 'packages', 'test-module2')
 
           callback = jasmine.createSpy('callback')

--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -21,7 +21,14 @@ setupTempDirectory = ->
     fs.makeTreeSync(temp.dir)
   temp.track()
 
+setupApmRcFile = ->
+  rcPath = path.resolve(__dirname, '..', '.apmrc')
+  cachePath = path.join(config.getAtomDirectory(), '.apm')
+  try
+    fs.writeFileSync(rcPath, "cache = #{cachePath}\n")
+
 setupTempDirectory()
+setupApmRcFile()
 
 commandClasses = [
   require './clean'

--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -28,7 +28,6 @@ setupApmRcFile = ->
     fs.writeFileSync(rcPath, "cache = #{cachePath}\n")
 
 setupTempDirectory()
-setupApmRcFile()
 
 commandClasses = [
   require './clean'
@@ -147,6 +146,7 @@ getPythonVersion = (callback) ->
 
 module.exports =
   run: (args, callback) ->
+    setupApmRcFile()
     options = parseOptions(args)
 
     unless options.argv.color

--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -21,12 +21,6 @@ setupTempDirectory = ->
     fs.makeTreeSync(temp.dir)
   temp.track()
 
-setupApmRcFile = ->
-  rcPath = path.resolve(__dirname, '..', '.apmrc')
-  cachePath = path.join(config.getAtomDirectory(), '.apm')
-  try
-    fs.writeFileSync(rcPath, "cache = #{cachePath}\n")
-
 setupTempDirectory()
 
 commandClasses = [
@@ -146,7 +140,7 @@ getPythonVersion = (callback) ->
 
 module.exports =
   run: (args, callback) ->
-    setupApmRcFile()
+    config.setupApmRcFile()
     options = parseOptions(args)
 
     unless options.argv.color

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -113,6 +113,6 @@ module.exports =
 
   setupApmRcFile = ->
     rcPath = path.resolve(__dirname, '..', '.apmrc')
-    cachePath = path.join(config.getAtomDirectory(), '.apm')
+    cachePath = path.join(@getAtomDirectory(), '.apm')
     try
       fs.writeFileSync(rcPath, "cache = #{cachePath}\n")

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -110,3 +110,9 @@ module.exports =
       return atomCommand if fs.existsSync(atomCommand)
 
     null
+
+  setupApmRcFile = ->
+    rcPath = path.resolve(__dirname, '..', '.apmrc')
+    cachePath = path.join(config.getAtomDirectory(), '.apm')
+    try
+      fs.writeFileSync(rcPath, "cache = #{cachePath}\n")

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -11,8 +11,8 @@ module.exports =
   getAtomDirectory: ->
     process.env.ATOM_HOME ? path.join(@getHomeDirectory(), '.atom')
 
-  getPackageCacheDirectory: ->
-    path.join(@getAtomDirectory(), '.node-gyp', '.atom', '.apm')
+  getCacheDirectory: ->
+    path.join(@getAtomDirectory(), '.apm')
 
   getResourcePath: (callback) ->
     if process.env.ATOM_RESOURCE_PATH
@@ -113,6 +113,5 @@ module.exports =
 
   setupApmRcFile: ->
     rcPath = path.resolve(__dirname, '..', '.apmrc')
-    cachePath = path.join(@getAtomDirectory(), '.apm')
     try
-      fs.writeFileSync(rcPath, "cache = #{cachePath}\n")
+      fs.writeFileSync(rcPath, "cache = #{@getCacheDirectory()}\n")

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -111,7 +111,7 @@ module.exports =
 
     null
 
-  setupApmRcFile = ->
+  setupApmRcFile: ->
     rcPath = path.resolve(__dirname, '..', '.apmrc')
     cachePath = path.join(@getAtomDirectory(), '.apm')
     try

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -294,7 +294,7 @@ class Install extends Command
   #
   # Returns a path to the cached tarball or undefined when not in the cache.
   getPackageCachePath: (packageName, packageVersion, callback) ->
-    cacheDir = config.getPackageCacheDirectory()
+    cacheDir = config.getCacheDirectory()
     cachePath = path.join(cacheDir, packageName, packageVersion, 'package.tgz')
     if fs.isFileSync(cachePath)
       tempPath = path.join(temp.mkdirSync(), path.basename(cachePath))


### PR DESCRIPTION
This PR dynamically generates the global `.apmrc` file so that it can properly respect the `ATOM_HOME` env var which might be used for portable Atom versions.

Refs https://github.com/atom/atom/issues/2939