### PR TITLE
Validate semver ranges before publishing

### DIFF
--- a/spec/publish-spec.coffee
+++ b/spec/publish-spec.coffee
@@ -1,0 +1,85 @@
+path = require 'path'
+fs = require 'fs-plus'
+temp = require 'temp'
+express = require 'express'
+http = require 'http'
+apm = require '../lib/apm-cli'
+
+describe 'apm publish', ->
+  [server] = []
+
+  beforeEach ->
+    spyOnToken()
+    silenceOutput()
+
+    app = express()
+    server =  http.createServer(app)
+    server.listen(3000)
+
+    atomHome = temp.mkdirSync('apm-home-dir-')
+    process.env.ATOM_HOME = atomHome
+    process.env.ATOM_API_URL = "http://localhost:3000/api"
+    process.env.ATOM_RESOURCE_PATH = temp.mkdirSync('atom-resource-path-')
+
+  afterEach ->
+    server.close()
+
+  it "validates the engines.atom range in the package.json file", ->
+    packageToPublish = temp.mkdirSync('apm-test-package-')
+    metadata =
+      name: 'test'
+      version: '1.0.0'
+      engines:
+        atom: '><>'
+    fs.writeFileSync(path.join(packageToPublish, 'package.json'), JSON.stringify(metadata))
+    process.chdir(packageToPublish)
+    callback = jasmine.createSpy('callback')
+    apm.run(['publish'], callback)
+
+    waitsFor 'waiting for publish to complete', 600000, ->
+      callback.callCount is 1
+
+    runs ->
+      expect(callback.mostRecentCall.args[0].message).toBe 'The Atom engine range is invalid: ><>'
+
+  it "validates the dependency semver ranges in the package.json file", ->
+    packageToPublish = temp.mkdirSync('apm-test-package-')
+    metadata =
+      name: 'test'
+      version: '1.0.0'
+      engines:
+        atom: '1'
+      dependencies:
+        foo: '^^'
+    fs.writeFileSync(path.join(packageToPublish, 'package.json'), JSON.stringify(metadata))
+    process.chdir(packageToPublish)
+    callback = jasmine.createSpy('callback')
+    apm.run(['publish'], callback)
+
+    waitsFor 'waiting for publish to complete', 600000, ->
+      callback.callCount is 1
+
+    runs ->
+      expect(callback.mostRecentCall.args[0].message).toBe 'The foo dependency range is invalid: ^^'
+
+  it "validates the dev dependency semver ranges in the package.json file", ->
+    packageToPublish = temp.mkdirSync('apm-test-package-')
+    metadata =
+      name: 'test'
+      version: '1.0.0'
+      engines:
+        atom: '1'
+      dependencies:
+        foo: '^5'
+      devDependencies:
+        bar: '1,3'
+    fs.writeFileSync(path.join(packageToPublish, 'package.json'), JSON.stringify(metadata))
+    process.chdir(packageToPublish)
+    callback = jasmine.createSpy('callback')
+    apm.run(['publish'], callback)
+
+    waitsFor 'waiting for publish to complete', 600000, ->
+      callback.callCount is 1
+
+    runs ->
+      expect(callback.mostRecentCall.args[0].message).toBe 'The bar dev dependency range is invalid: 1,3'

--- a/spec/publish-spec.coffee
+++ b/spec/publish-spec.coffee
@@ -40,7 +40,7 @@ describe 'apm publish', ->
       callback.callCount is 1
 
     runs ->
-      expect(callback.mostRecentCall.args[0].message).toBe 'The Atom engine range is invalid: ><>'
+      expect(callback.mostRecentCall.args[0].message).toBe 'The Atom engine range in the package.json file is invalid: ><>'
 
   it "validates the dependency semver ranges in the package.json file", ->
     packageToPublish = temp.mkdirSync('apm-test-package-')
@@ -60,7 +60,7 @@ describe 'apm publish', ->
       callback.callCount is 1
 
     runs ->
-      expect(callback.mostRecentCall.args[0].message).toBe 'The foo dependency range is invalid: ^^'
+      expect(callback.mostRecentCall.args[0].message).toBe 'The foo dependency range in the package.json file is invalid: ^^'
 
   it "validates the dev dependency semver ranges in the package.json file", ->
     packageToPublish = temp.mkdirSync('apm-test-package-')
@@ -82,4 +82,4 @@ describe 'apm publish', ->
       callback.callCount is 1
 
     runs ->
-      expect(callback.mostRecentCall.args[0].message).toBe 'The bar dev dependency range is invalid: 1,3'
+      expect(callback.mostRecentCall.args[0].message).toBe 'The bar dev dependency range in the package.json file is invalid: 1,3'

--- a/src/publish.coffee
+++ b/src/publish.coffee
@@ -298,19 +298,19 @@ class Publish extends Command
       try
         new semver.Range(pack.engines.atom)
       catch error
-        throw new Error("The Atom engine range is invalid: #{pack.engines.atom}")
+        throw new Error("The Atom engine range in the package.json file is invalid: #{pack.engines.atom}")
 
     for packageName, semverRange of pack.dependencies
       try
         new semver.Range(semverRange)
       catch error
-        throw new Error("The #{packageName} dependency range is invalid: #{semverRange}")
+        throw new Error("The #{packageName} dependency range in the package.json file is invalid: #{semverRange}")
 
     for packageName, semverRange of pack.devDependencies
       try
         new semver.Range(semverRange)
       catch error
-        throw new Error("The #{packageName} dev dependency range is invalid: #{semverRange}")
+        throw new Error("The #{packageName} dev dependency range in the package.json file is invalid: #{semverRange}")
 
     return
 

--- a/src/publish.coffee
+++ b/src/publish.coffee
@@ -294,7 +294,7 @@ class Publish extends Command
   validateSemverRanges: (pack) ->
     return unless pack
 
-    if pack.engines.atom?
+    if pack.engines?.atom?
       try
         new semver.Range(pack.engines.atom)
       catch error

--- a/src/publish.coffee
+++ b/src/publish.coffee
@@ -291,7 +291,7 @@ class Publish extends Command
     pack.name = name
     @saveMetadata(pack, callback)
 
-  validateSemverValues: (pack) ->
+  validateSemverRanges: (pack) ->
     return unless pack
 
     if pack.engines.atom?
@@ -327,7 +327,7 @@ class Publish extends Command
       return callback(error)
 
     try
-      @validateSemverValues(pack)
+      @validateSemverRanges(pack)
     catch error
       return callback(error)
 


### PR DESCRIPTION
Checks that the `engines.atom`, `dependencies`, and `devDependencies` semver ranges are valid in the `package.json` before allowing publishing to occur.

This fixes the case where a package can be published with an invalid engines field that won't be listed as compatible and so it actually can't be installed in any Atom version.

Closes #291 