### PR TITLE
Fix missing symbol issue on Darwin, version bump, rewrite `apm` script.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -23,7 +23,7 @@ module.exports = (grunt) ->
 
     shell:
       test:
-        command: 'node --harmony_collections node_modules/jasmine-focused/bin/jasmine-focused --captureExceptions --coffee spec/'
+        command: 'node node_modules/jasmine-focused/bin/jasmine-focused --captureExceptions --coffee spec/'
         options:
           stdout: true
           stderr: true

--- a/bin/apm
+++ b/bin/apm
@@ -1,40 +1,76 @@
-#!/bin/bash
+#!/bin/sh -e #  apm  - Atom Package Manager powered by https://atom.io
 
-set -e
+# node_flags="--harmony_collections"       ## Uncomment for node < 0.12.0.
 
-initialCwd=`pwd -P`
+unset -f cd 2>/dev/null ||: alias cd=\cd   ## Kill heinous cd hooks (rvm).
 
-apmPath=$0
-builtin cd "`dirname "$apmPath"`"
-binDir=`basename "$apmPath"`
+[ -"$BASH_VERSION"- != -""- ] && set -o posix  ## Try to get a sane shell.
+[ -"$ZSH_VERSION"-  != -""- ] && emulate sh && setopt shwordsplit
 
-# Detect CPU arch.
-archs=`uname -m`
-case "$archs" in
-  i?86) archs='ia32' ;;
-  x86_64) archs='x64' ;;
-  *) archs='arm' ;;
-esac
+#===------------------------------------------------------- readlink() -===##
+readlink(){ ## Pure XSI/POSIX shellreadlink(1), with GNU extensions (minifed).
+## 2014, Geoff Nixon. Public domain. Find it at http://github.com/geoff-codes.
 
-# Detect current OS, see http://stackoverflow.com/q/3466166/682252.
-if [ "`uname`" == 'Darwin' ]; then
-  nodeBin="node"
-elif [ "`expr substr $(uname -s) 1 5`" == 'Linux' ]; then
-  nodeBin="node"
-elif [ "`expr substr $(uname -s) 1 10`" == 'MINGW32_NT' ]; then
-  nodeBin="node.exe"
-else
-  echo "Your platform (`uname -a`) is not supported."
-  exit 1
-fi
+  readlink_exists=1; readlink_dirs_exist=1
+  readlink_sep=''; readlink_print=echo
+  OPTIND=1; while getopts "efhmnqsvz?" readlink_opt; do
+      case "$readlink_opt" in
+        e) readlink_realpath=1; readlink_dirs_exist=1; readlink_exists=1 ;;
+        f) readlink_realpath=1; readlink_dirs_exist=1; readlink_exists=  ;;
+        m) readlink_realpath=1; readlink_dirs_exist= ; readlink_exists=  ;;
+        n) readlink_print=printf                                         ;;
+        z) readlink_print=printf; readlink_sep='\0';;
+      esac
+  done; shift $((OPTIND - 1))
 
-while [ -L "$binDir" ]
-do
-  binDir=`readlink "$binDir"`
-  builtin cd "`dirname "$binDir"`"
-  binDir=`basename "$binDir"`
-done
+  readlink_readlink () {
+    readlink_readlink="$(ls -ld "$@" | sed 's|.* -> ||')"
+    [ -$readlink_realpath- != -- ]                        &&
+      [ "$(echo "$readlink_readlink" | cut -c1)" != "/" ] &&
+      readlink_readlink="$(pwd -P)/$readlink_readlink"
+    echo "$readlink_readlink" ;}
 
-binDir=`pwd -P`
-builtin cd "$initialCwd"
-"$binDir/$nodeBin" --harmony_collections "$binDir/../lib/cli.js" "$@"
+  readlink_canonicalize () {
+    readlink_canon="$(pwd -P)/$(basename "$@")"
+    readlink_canonical="$(echo "$readlink_canon" | sed 's|//|/|g')"
+    echo "$readlink_canonical" ;}
+
+  readlink_no_dir () {
+    [ -$readlink_dirs_exist- = -- ] &&
+      $readlink_print "$@$readlink_sep" && exit 0 ;}
+
+  readlink_no_target () {
+    [ -$readlink_exists- = -- ]                                    &&
+      $readlink_print "$(readlink_canonicalize "$@")$readlink_sep" && exit 0;}
+
+  readlink_not_link () {
+    [ -$readlink_realpath- != -- ]                       &&
+      readlink_canonical="$(readlink_canonicalize "$@")" &&
+      $readlink_print "$readlink_canonical$readlink_sep" && exit 0 ;}
+
+  readlink_try (){
+    readlink_cur_dir="$(dirname "$@")"; readlink_cur_base="$(basename "$@")"
+    cd "$readlink_cur_dir" 2>/dev/null || readlink_no_dir             "$@"
+
+    [ -e "$readlink_cur_base" ] || readlink_no_target "$(pwd -P)/$@"
+    [ -L "$readlink_cur_base" ] || readlink_not_link            "$@"
+
+    readlink_readlink="$(readlink_readlink "$readlink_cur_base")"
+
+    [ -$readlink_realpath- = -- ]                                 &&
+      $readlink_print "$readlink_readlink$readlink_sep" && exit 0 ||
+      readlink_try "$readlink_readlink" ;}
+
+  for readlink_target; do :; done; readlink_try "$readlink_target"
+} ##===---------------------------------------------------- readlink() -===##
+
+apmroot="$(dirname "$(readlink -f ""$("$(dirname "$0")")")"
+
+node="$apmroot/bin/node" ; clijs="$apmroot/lib/cli.js"
+
+uname | grep MINGW >/dev/null && exec "$node.exe" $node_flags "$clijs" "$@"
+
+[ -"$(uname)"- != -"Darwin"- ] && [ -"$(uname)"- != -Linux- ]  &&
+echo "Sorry, $(uname) is not a supported platform." >&2 && exit 1
+
+exec "$node" $node_flags "$apmroot/lib/cli.js" "$@"

--- a/bin/apm.cmd
+++ b/bin/apm.cmd
@@ -1,6 +1,6 @@
 @IF EXIST "%~dp0\node.exe" (
-  "%~dp0\node.exe" --harmony_collections "%~dp0/../lib/cli.js" %*
+  "%~dp0\node.exe" "%~dp0/../lib/cli.js" %*
 ) ELSE (
-  node.exe --harmony_collections "%~dp0/../lib/cli.js" %*
+  node.exe "%~dp0/../lib/cli.js" %*
 )
 

--- a/script/download-node.js
+++ b/script/download-node.js
@@ -104,7 +104,7 @@ var downloadNode = function(version, done) {
   }
 };
 
-downloadNode('v0.10.35', function(error) {
+downloadNode('v0.12.0', function(error) {
   if (error != null) {
     console.error('Failed to download node', error);
     return process.exit(1);


### PR DESCRIPTION
:apple::facepunch::bug::arrow_up::art::fire::bathtub::package::arrow_right::v::octocat:

The long-standing issue of build failures due to missing symbols on Mac OS X [(#3184)](https://github.com/atom/atom/issues/3184) is the result of building modules with the 'system' node, as the build scripts require one. But the off-the-shelf 0.10.35 package that is download when apm is installed is not ABI compatible (This version of node is missing the `_node_module_register` symbol, which must be found in node binary when these modules are `dlopen()`d.

The simplest way to fix this ...is simply to bump node to v0.12.0. As it *has* now been released (and is a "stable" release), and because the apm test suite appears to have absolutely no issue with it, I have (hesitantly) done so in this PR. Hopefully this won't break things spectacularly.

ONE thing little thing this *does* break is the utilization of the `--harmony_collections` flag, whij has been removed as it is no longer needed. I have removed this flag in places where necessary.

Also, I rewrote your `apm` script. It kinda made me sad. This should be considerably more robust.

All the best,
-G