### PR TITLE
Make `keytar` an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "colors": "~0.6.1",
     "wordwrap": "0.0.2",
     "fs-plus": "2.x",
-    "keytar": ">=2.1 <3",
     "read": "~1.0.5",
     "q": "~0.9.7",
     "plist": "git+https://github.com/nathansobo/node-plist.git",
@@ -55,5 +54,8 @@
     "express": "~3.2.3",
     "grunt-coffeelint": "0.0.6",
     "coffee-script": "^1.8.0"
+  },
+  "optionalDependencies": {
+    "keytar": ">=2.1 <3"
   }
 }


### PR DESCRIPTION
As keytar's build can often fail (see atom/node-keytar#7 and atom/node-keytar#18) and it's already made optional on top of `src/auth.js`, why not make the dependency optional?
With current config it will fail at `npm install` whereas apm could completely work without it.