### PR TITLE
Bump year in template licenses to 2015

### DIFF
--- a/templates/language/LICENSE.md
+++ b/templates/language/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2014 <Your name here>
+Copyright (c) 2015 <Your name here>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/templates/package/LICENSE.md
+++ b/templates/package/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2014 <Your name here>
+Copyright (c) 2015 <Your name here>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/templates/theme/LICENSE.md
+++ b/templates/theme/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2014 <Your name here>
+Copyright (c) 2015 <Your name here>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
I noticed this while generating some packages with `apm init`. Maybe its worth making the year dynamic so its always the current year? Happy to make this change.