### PR TITLE
:art: changed constructor's argument name to `serializedState` in template for package view

### DIFF
--- a/templates/package/lib/__package-name__-view.coffee.template
+++ b/templates/package/lib/__package-name__-view.coffee.template
@@ -1,6 +1,6 @@
 module.exports =
 class __PackageName__View
-  constructor: (serializeState) ->
+  constructor: (serializedState) ->
     # Create root element
     @element = document.createElement('div')
     @element.classList.add('__package-name__')


### PR DESCRIPTION
The argument object is the serialized state. Makes more sense, imo.

```coffee
  constructor: (serializeState) ->
```
to
```coffee
  constructor: (serializedState) ->
```