### PR TITLE
Don't limit by operating system type. Default to reasonable node binary

### DIFF
--- a/bin/apm
+++ b/bin/apm
@@ -8,24 +8,11 @@ apmPath=$0
 builtin cd "`dirname "$apmPath"`"
 binDir=`basename "$apmPath"`
 
-# Detect CPU arch.
-archs=`uname -m`
-case "$archs" in
-  i?86) archs='ia32' ;;
-  x86_64) archs='x64' ;;
-  *) archs='arm' ;;
-esac
-
-# Detect current OS, see http://stackoverflow.com/q/3466166/682252.
-if [ "`uname`" == 'Darwin' ]; then
-  nodeBin="node"
-elif [ "`expr substr $(uname -s) 1 5`" == 'Linux' ]; then
-  nodeBin="node"
-elif [ "`expr substr $(uname -s) 1 10`" == 'MINGW32_NT' ]; then
+# Detect node binary name
+if [ "`expr substr $(uname -s) 1 10`" == 'MINGW32_NT' ]; then
   nodeBin="node.exe"
 else
-  echo "Your platform (`uname -a`) is not supported."
-  exit 1
+  nodeBin="node"
 fi
 
 while [ -L "$binDir" ]


### PR DESCRIPTION
archs is unused in this file. Remove.
Don't limit use by operating system. Set correctly for Windows and pick reasonable default for all else.
This fixes a problem on FreeBSD.