### PR TITLE
Use bash substrings instead of expr non-posix substrings for portability.

### DIFF
--- a/bin/apm
+++ b/bin/apm
@@ -9,7 +9,8 @@ builtin cd "`dirname "$apmPath"`"
 binDir=`basename "$apmPath"`
 
 # Detect node binary name
-if [ "`uname`" != 'Darwin' ] && [ "`expr substr $(uname -s) 1 10`" == 'MINGW32_NT' ]; then
+osName=`uname -s`
+if [ "${osName:0:10}" == 'MINGW32_NT' ]; then
   nodeBin="node.exe"
 else
   nodeBin="node"


### PR DESCRIPTION
I've tested this on OS X, debian, and FreeBSD. I don't have the ability to test on Windows.