### PR TITLE
Catch 404 not found case and quit stream before passing zlib empty file

### DIFF
--- a/script/download-node.js
+++ b/script/download-node.js
@@ -37,8 +37,14 @@ var downloadTarballAndExtract = function(url, location, callback) {
   });
   stream.on('end', callback.bind(this, tempPath));
   stream.on('error', callback);
-  request.createReadStream({url: url}, function(requestStream) {
-    requestStream.pipe(zlib.createGunzip()).pipe(stream);
+  request.createReadStream({url: url}, function(res) {
+    res.on('response', function (resp) {
+      if (resp.statusCode == 404) {
+        console.error('download not found:', url);
+        process.exit(1);
+      }
+      res.pipe(zlib.createGunzip()).pipe(stream);
+    });
   });
 };
 

--- a/script/download-node.js
+++ b/script/download-node.js
@@ -37,13 +37,13 @@ var downloadTarballAndExtract = function(url, location, callback) {
   });
   stream.on('end', callback.bind(this, tempPath));
   stream.on('error', callback);
-  request.createReadStream({url: url}, function(res) {
-    res.on('response', function (resp) {
-      if (resp.statusCode == 404) {
+  request.createReadStream({url: url}, function(requestStream) {
+    requestStream.on('response', function(response) {
+      if (response.statusCode == 404) {
         console.error('download not found:', url);
         process.exit(1);
       }
-      res.pipe(zlib.createGunzip()).pipe(stream);
+      requestStream.pipe(zlib.createGunzip()).pipe(stream);
     });
   });
 };


### PR DESCRIPTION
Currently, if you try to download node for unsupported architecture/operating system, you get an exception because it passes a null stream to zlib to decompress.

events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: incorrect header check
    at Zlib._binding.onerror (zlib.js:296:17)

This change results in and error being printed:
download not found: http://nodejs.org/dist/v0.10.35/node-v0.10.35-freebsd-x64.tar.gz
