### PR TITLE
Add keywords field to package templates

### DIFF
--- a/templates/bundle/package.json
+++ b/templates/bundle/package.json
@@ -2,6 +2,8 @@
   "name": "__package-name__",
   "version": "0.0.0",
   "description": "A short description of your package",
+  "keywords": [
+  ],
   "repository": "https://github.com/__package-author__/__package-name__",
   "license": "MIT",
   "engines": {

--- a/templates/language/package.json
+++ b/templates/language/package.json
@@ -2,6 +2,10 @@
   "name": "language-__package-name__",
   "version": "0.0.0",
   "description": "A short description of your language package",
+  "keywords": [
+    "language",
+    "grammar"
+  ],
   "repository": "https://github.com/__package-author__/language-__package-name__",
   "license": "MIT",
   "engines": {

--- a/templates/package/package.json
+++ b/templates/package/package.json
@@ -3,6 +3,8 @@
   "main": "./lib/__package-name__",
   "version": "0.0.0",
   "description": "A short description of your package",
+  "keywords": [
+  ],
   "activationCommands": {
     "atom-workspace": "__package-name__:toggle"
   },

--- a/templates/theme/package.json
+++ b/templates/theme/package.json
@@ -3,6 +3,10 @@
   "theme": "syntax",
   "version": "0.0.0",
   "description": "A short description of your syntax theme",
+  "keywords": [
+    "syntax",
+    "theme"
+  ],
   "repository": "https://github.com/__package-author__/__package-name__",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This adds the `keywords` field to package templates as a gentle nudge for users to add keywords when creating packages. Motivation: http://blog.atom.io/2015/03/30/keywords-on-atom-io.html + https://github.com/atom/deprecation-cop/issues/32 

cc @lee-dohm