### PR TITLE
Don't install or show search results for deprecated packages

### DIFF
--- a/deprecated-packages.json
+++ b/deprecated-packages.json
@@ -1,0 +1,1710 @@
+{
+  "advanced-new-file": {
+    "version": "<=0.4.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "agda-mode": {
+    "version": "<=0.2.17",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "apex-ui-personalize": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "api-blueprint-preview": {
+    "version": "<=0.3.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "asciidoc-preview": {
+    "version": "<=0.5.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "ask-stack": {
+    "version": "<=1.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "assign-align": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-2048": {
+    "version": "<=1.2.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-angularjs": {
+    "hasAlternative": true,
+    "alternative": "angularjs"
+  },
+  "atom-beautifier": {
+    "version": "<=0.5.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-beautify": {
+    "version": "<=0.27.7",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "atom-browser-webview": {
+    "version": "<=0.6.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-charcode": {
+    "version": "<=0.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-cli-diff": {
+    "version": "<=0.11.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-compile-coffee": {
+    "version": "<=1.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "atom-ctags": {
+    "version": "<=3.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-deconsole": {
+    "version": "<=0.0.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-faker": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-flake8": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-grunt-configs": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-html-preview": {
+    "version": "<=0.1.4",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "atom-html5-boilerplate": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-htmlizer": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-jsfmt": {
+    "version": "<=0.6.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "atom-jshint": {
+    "version": "<=1.5.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "atom-lint": {
+    "hasAlternative": true,
+    "alternative": "linter"
+  },
+  "atom-pair": {
+    "version": "<=1.1.5",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "atom-prettify": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-processing": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-python-debugger": {
+    "version": "<=0.2.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "atom-rails": {
+    "version": "<=0.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-raml-preview": {
+    "version": "<=0.0.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-runner": {
+    "version": "<=2.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "atom-semicolons": {
+    "version": "<=0.1.5",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-spotify": {
+    "version": "<=1.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atom-terminal-panel": {
+    "version": "<=4.3.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "atom-yeoman": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "atomatigit": {
+    "version": "<=1.5.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "atomic-emacs": {
+    "version": "<=0.5.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "atomic-rest": {
+    "version": "<=0.2.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "auto-copyright": {
+    "version": "<=0.3.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "auto-detect-indentation": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "auto-indent": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "auto-replace-in-selection": {
+    "version": "<=2.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "auto-update-packages": {
+    "version": "<=0.2.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "autoclose-html": {
+    "version": "<=0.15.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "autocomplete-haskell": {
+    "version": "<=0.2.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "autocomplete-jedi": {
+    "hasAlternative": true,
+    "alternative": "autocomplete-plus-python-jedi"
+  },
+  "autocomplete-modules": {
+    "version": "<=0.3.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "autocomplete-paths": {
+    "version": "<=1.0.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "autocomplete-phpunit": {
+    "version": "<=1.0.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "autocomplete-plus-async": {
+    "hasAlternative": true,
+    "message": "`autocomplete-plus-async` has been replaced by `autocomplete-plus` which is bundled in core",
+    "alternative": "core"
+  },
+  "autocomplete-plus-jedi": {
+    "version": "<=0.0.9",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "autocomplete-snippets": {
+    "version": "<=1.0.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "bezier-curve-editor": {
+    "version": "<=0.6.6",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "block-comment": {
+    "version": "<=0.4.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "block-travel": {
+    "version": "<=0.10.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "browser-refresh": {
+    "version": "<=0.8.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "build-systems": {
+    "version": "<=0.5.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "cabal": {
+    "version": "<=0.0.13",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "caniuse": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "change-case": {
+    "version": "<=0.5.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "circle-ci": {
+    "version": "<=0.9.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "clang-format": {
+    "version": "<=1.5.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "clipboard-history": {
+    "version": "<=0.6.5",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "close-after-last-tab": {
+    "version": "<=0.1.5",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "closure-linter": {
+    "version": "<=0.2.5",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "codeship-status": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "coffee-compile": {
+    "version": "<=0.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "coffee-lint": {
+    "version": "<=0.7.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "coffee-navigator": {
+    "version": "<=0.0.16",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "coffee-trace": {
+    "version": "<=0.2.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "coffeescript-preview": {
+    "hasAlternative": true,
+    "alternative": "preview"
+  },
+  "color": {
+    "version": "<=0.5.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "color-picker": {
+    "version": "<=1.7.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "command-logger": {
+    "version": "<=0.20.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "comment": {
+    "version": "<=0.2.7",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "compass": {
+    "version": "<=0.8.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "composer": {
+    "version": "<=0.3.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "convert-to-utf8": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "coverage": {
+    "version": "<=0.6.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "csscomb": {
+    "version": "<=0.1.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "ctags-status": {
+    "version": "<=1.2.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "cucumber-runner": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "cucumber-step": {
+    "version": "<=0.1.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "custom-title": {
+    "version": "<=0.7.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "cut-line": {
+    "hasAlternative": true,
+    "alternative": "core"
+  },
+  "dart-tools": {
+    "version": "<=0.9.11",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "dash": {
+    "version": "<=1.0.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "data-atom": {
+    "version": "<=0.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "devdocs": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "django-templates": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "docblockr": {
+    "version": "<=0.6.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "easy-motion": {
+    "version": "<=1.1.4",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "editor-stats": {
+    "version": "<=0.16.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "editorconfig": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "elixir-cmd": {
+    "version": "<=0.2.6",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "emacs-mode": {
+    "version": "<=0.0.29",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "ember-cli-helper": {
+    "version": "<=0.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "emmet": {
+    "version": "<=2.3.7",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "emp-debugger": {
+    "version": "<=0.6.13",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "emp-template-management": {
+    "version": "<=0.1.13",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "enhanced-package-list": {
+    "version": "<=1.0.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "enhanced-tabs": {
+    "version": "<=1.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "erb-snippets": {
+    "version": "<=0.5.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "error-status": {
+    "version": "<=0.3.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "eslint": {
+    "version": "<=0.15.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "eval": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "ever-notedown": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "ex-mode": {
+    "version": "<=0.4.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "execute-as-ruby": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "expand-selection": {
+    "version": "<=0.2.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "explicit-reload": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "fancy-new-file": {
+    "version": "<=0.7.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "file-icon-supplement": {
+    "version": "<=0.7.10",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "file-types": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "filetype-color": {
+    "version": "<=0.1.4",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "firepad": {
+    "version": "<=0.3.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "flake8": {
+    "hasAlternative": true,
+    "alternative": "linter"
+  },
+  "floobits": {
+    "version": "<=0.4.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "function-name-in-status-bar": {
+    "version": "<=0.2.6",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "fuzzy-finder": {
+    "version": "<=0.54.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "fuzzy-finder-plus": {
+    "version": "<=1.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "get-routes": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "gist-it": {
+    "version": "<=0.6.10",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "git-blame": {
+    "version": "<=0.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "git-control": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "git-diff-details": {
+    "version": "<=0.8.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "git-grep": {
+    "version": "<=0.9.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "git-log": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "git-plus": {
+    "version": "<=4.5.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "git-projects": {
+    "version": "<=1.14.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "git-tab-status": {
+    "version": "<=1.5.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "github-issues": {
+    "version": "<=0.5.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "go-oracle": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "go-plus": {
+    "version": "<=3.0.9",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "go-to-view": {
+    "version": "<=0.1.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "gradle-ci": {
+    "version": "<=0.2.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "grammar-selector": {
+    "version": "<=0.35.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "grunt-runner": {
+    "version": "<=0.8.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "gulp-helper": {
+    "version": "<=4.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "gutter-shadow": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "hiera-eyaml": {
+    "version": "<=0.4.7",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "highlight-column": {
+    "version": "<=0.3.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "highlight-cov": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "highlight-css-color": {
+    "version": "<=1.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "highlight-line": {
+    "version": "<=0.9.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "highlight-selected": {
+    "version": "<=0.7.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "hipster-ipsum": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "html-entities": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "html-helper": {
+    "version": "<=0.2.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "html-img": {
+    "version": "<=0.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "html2haml": {
+    "version": "<=0.6.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "html2jade": {
+    "version": "<=0.7.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "htmlhint": {
+    "version": "<=1.0.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "icon-font-picker": {
+    "version": "<=0.0.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "ide-flow": {
+    "version": "<=0.7.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "ide-haskell": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "inc-dec-value": {
+    "version": "<=0.0.7",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "increment-number": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "indent-guide-improved": {
+    "version": "<=1.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "indent-helper": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "indentation-jumper": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "inline-autocomplete": {
+    "version": "<=1.0.4",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "ionic-atom": {
+    "version": "<=0.3.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "ionic-preview": {
+    "version": "<=0.3.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "japanese-zen-han-convert": {
+    "version": "<=0.3.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "jekyll": {
+    "version": "<=0.4.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "jsdoc": {
+    "version": "<=0.9.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "jsformat": {
+    "version": "<=0.8.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "jslint": {
+    "version": "<=0.10.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "jsonlint": {
+    "version": "<=1.0.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "jsonpp": {
+    "version": "<=0.0.7",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "keycodes": {
+    "version": "<=0.1.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "language-javascript-semantic": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "language-jsoniq": {
+    "version": "<=1.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "language-rspec": {
+    "version": "<=0.2.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "language-typescript": {
+    "hasAlternative": true,
+    "alternative": "atom-typescript"
+  },
+  "laravel-facades": {
+    "version": "<=1.0.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "last-cursor-position": {
+    "version": "<=0.6.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "layout-manager": {
+    "version": "<=0.2.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "less-autocompile": {
+    "version": "<=0.3.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "less-than-slash": {
+    "version": "<=0.4.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "letter-spacing": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "line-jumper": {
+    "version": "<=0.13.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "linter": {
+    "version": "<=0.11.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "linter-flow": {
+    "version": "<=0.1.4",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "livereload": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "local-history": {
+    "version": "<=3.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "local-server": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "local-server-express": {
+    "version": "<=0.2.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "local-settings": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "localeapp": {
+    "version": "<=0.1.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "localization": {
+    "version": "<=1.16.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "log-console": {
+    "version": "<=0.1.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "lorem-ipsum": {
+    "version": "<=0.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "mark-ring": {
+    "version": "<=3.0.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "markdown-format": {
+    "version": "<=2.5.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "markdown-helpers": {
+    "version": "<=0.2.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "markdown-pdf": {
+    "version": "<=1.3.6",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "markdown-preview-pandoc": {
+    "version": "<=0.0.13",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "markdown-preview-plus": {
+    "version": "<=1.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "markdown-stream": {
+    "version": "<=0.6.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "markdown-writer": {
+    "version": "<=1.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "marked": {
+    "version": "<=0.1.8",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "mate-subword-navigation": {
+    "version": "<=3.0.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "MavensMate-Atom": {
+    "version": "<=0.0.20",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "max-tabs": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "maximize-panes": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "mechanical-keyboard": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "minifier": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "minimap": {
+    "version": "<=3.5.6",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "minimap-color-highlight": {
+    "version": "<=4.1.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "minimap-git-diff": {
+    "version": "<=3.0.4",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "mocha": {
+    "version": "<=0.0.5",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "mocha-ui": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "move-panes": {
+    "version": "<=0.1.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "node-debugger": {
+    "version": "<=0.2.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "node-resolver": {
+    "version": "<=1.0.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "npm-autocomplete": {
+    "version": "<=0.1.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "npm-docs": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "npm-install": {
+    "version": "<=3.0.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "nrepl": {
+    "version": "<=0.0.6",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "omni-ruler": {
+    "version": "<=0.3.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "omnisharp-atom": {
+    "version": "<=0.4.9",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "open-in": {
+    "version": "<=3.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "open-in-github-app": {
+    "version": "<=0.2.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "open-last-project": {
+    "hasAlternative": true,
+    "alternative": "core"
+  },
+  "open-plus": {
+    "version": "<=0.3.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "open-recent": {
+    "version": "<=2.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "open-sesame": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "package-cop": {
+    "version": "<=0.2.5",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "package-list-downloader": {
+    "version": "<=0.2.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "pain-split": {
+    "version": "<=1.1.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "pane-layout-switcher": {
+    "version": "<=0.0.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "party-hard": {
+    "version": "<=0.3.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "pep8": {
+    "hasAlternative": true,
+    "alternative": "linter"
+  },
+  "pepper-autocomplete": {
+    "version": "<=0.6.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "perltidy": {
+    "version": "<=2.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "permute": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "php-documentation-online": {
+    "version": "<=0.2.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "php-getters-setters": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "phpunit": {
+    "version": "<=1.0.9",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "playlist": {
+    "version": "<=0.1.7",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "pretty-json": {
+    "version": "<=0.3.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "preview": {
+    "version": "<=0.14.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "preview-plus": {
+    "version": "<=1.1.19",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "project-manager": {
+    "version": "<=1.15.5",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "project-palette-finder": {
+    "version": "<=2.4.17",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "project-ring": {
+    "version": "<=0.19.6",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "python": {
+    "hasAlternative": true,
+    "alternative": "script"
+  },
+  "python-coverage": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "python-isort": {
+    "version": "<=0.0.6",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "python-jedi": {
+    "version": "<=0.1.7",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "quick-move-file": {
+    "version": "<=0.7.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "rails-navigation": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "react": {
+    "version": "<=0.7.8",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "recent-files": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "recent-projects": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "regex-railroad-diagram": {
+    "version": "<=0.7.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "related-files": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "remote-atom": {
+    "version": "<=1.1.10",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "remote-edit": {
+    "version": "<=1.6.4",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "remote-sync": {
+    "version": "<=3.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "resize-panes": {
+    "hasAlternative": true,
+    "alternative": "core"
+  },
+  "rest-client": {
+    "version": "<=0.3.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "revert-buffer": {
+    "version": "<=0.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "rhino-python": {
+    "version": "<=0.6.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "rsense": {
+    "version": "<=0.6.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "rspec": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "rst-preview-pandoc": {
+    "version": "<=0.1.6",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "ruby-define-method": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "ruby-hash-rocket": {
+    "version": "<=1.1.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "ruby-quick-test": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "ruby-strftime-reference": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "ruby-test": {
+    "version": "<=0.9.5",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "run-command": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "run-in-browser": {
+    "version": "<=0.1.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "runcoderun": {
+    "version": "<=0.5.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "sass-autocompile": {
+    "version": "<=0.6.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "sassbeautify": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "save-commands": {
+    "version": "<=0.6.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "save-session": {
+    "version": "<=0.15.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "scope-inspector": {
+    "version": "<=0.2.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "script": {
+    "version": "<=2.20.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "script-runner": {
+    "version": "<=1.6.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "selection-count": {
+    "hasAlternative": true,
+    "alternative": "core"
+  },
+  "slash-closer": {
+    "version": "<=0.7.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "sloc": {
+    "version": "<=0.1.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "smarter-delete-line": {
+    "version": "<=1.0.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "space-block-jumper": {
+    "version": "<=0.4.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "space-tab": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "spark-dfu-util": {
+    "version": "<=0.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "status-tab-spacing": {
+    "version": "<=0.3.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "sublime-tabs": {
+    "version": "<=0.5.6",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "supercollider": {
+    "version": "<=0.4.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "supercopair": {
+    "version": "<=0.9.34",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "swift-playground": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "symbol-gen": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "synced-sidebar": {
+    "version": "<=0.2.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "tab-history": {
+    "version": "<=0.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "tab-move-key": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "tab-switcher": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "tabs-to-spaces": {
+    "version": "<=0.8.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "tag": {
+    "version": "<=0.2.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "task-list": {
+    "version": "<=0.7.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "tasks": {
+    "version": "<=1.0.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "terminal-panel": {
+    "version": "<=1.11.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "terminal-status": {
+    "version": "<=1.6.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "test-status": {
+    "version": "<=0.27.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "ti-alloy-related": {
+    "version": "<=0.6.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "tidal": {
+    "version": "<=0.6.6",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "tidy-markdown": {
+    "version": "<=0.2.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "todo-list": {
+    "version": "<=1.0.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "toggle-tabs": {
+    "version": "<=0.1.8",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "travis-ci-status": {
+    "version": "<=0.13.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "tree-view": {
+    "version": "<=0.172.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "tree-view-breadcrumb": {
+    "version": "<=0.2.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "turbo-javascript": {
+    "version": "<=0.0.10",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "turnip-step": {
+    "version": "<=1.0.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "unity-dark-ui": {
+    "version": "<=1.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "unity-ui": {
+    "version": "<=1.0.5",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "update-packages": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "url-encode": {
+    "version": "<=0.4.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "vertical-align": {
+    "version": "<=0.6.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "view-tail-large-files": {
+    "version": "<=0.1.16",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "vim-mode": {
+    "version": "<=0.46.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "virtualenv": {
+    "version": "<=0.6.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "visual-bell": {
+    "version": "<=0.11.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "voicecode": {
+    "version": "<=0.9.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "w3c-validation": {
+    "version": "<=0.1.3",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "weather-package": {
+    "version": "<=1.5.4",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "web-view": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "webbox-color": {
+    "version": "<=0.5.4",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "webview-pane": {
+    "version": "<=0.0.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "wercker-status": {
+    "version": "<=0.3.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "whitespace": {
+    "version": "<=0.24.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "word-count": {
+    "version": "<=0.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "word-jumper": {
+    "version": "<=0.2.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "wordcount": {
+    "version": "<=2.1.0",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  },
+  "wrap-lines": {
+    "hasAlternative": true,
+    "message": "`wrap-lines` has been replaced by a feature in core. Open the command palette and search for `autoflow`.",
+    "alternative": "core"
+  },
+  "yosemite-unity-ui": {
+    "version": "<=0.3.13",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "yuno-commit": {
+    "version": "<=0.0.2",
+    "hasDeprecations": true,
+    "latestHasDeprecations": true
+  },
+  "zentabs": {
+    "version": "<=0.6.1",
+    "hasDeprecations": true,
+    "latestHasDeprecations": false
+  }
+}

--- a/spec/fixtures/atom-2048.json
+++ b/spec/fixtures/atom-2048.json
@@ -1,0 +1,14 @@
+
+{
+  "releases": {
+    "latest": "1.2.3"
+  },
+  "name": "atom-2048",
+  "versions": {
+    "1.2.3": {
+      "dist": {
+        "tarball": "http://localhost:3000/tarball/test-module-1.0.0.tgz"
+      }
+    }
+  }
+}

--- a/spec/fixtures/search.json
+++ b/spec/fixtures/search.json
@@ -32,5 +32,16 @@
       "theme": true,
       "description": "Racecars, lasers, airplanes"
     }
+  },
+  {
+    "name": "atom-2048",
+    "releases": {
+      "latest": "1.2.3"
+    },
+    "metadata": {
+      "name": "atom-2048",
+      "version": "1.2.3",
+      "description": "Racecars, lasers, airplanes"
+    }
   }
 ]

--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -52,6 +52,8 @@ describe 'apm install', ->
         response.sendfile path.join(__dirname, 'fixtures', 'test-module-with-bin-2.0.0.tgz')
       app.get '/packages/multi-module', (request, response) ->
         response.sendfile path.join(__dirname, 'fixtures', 'install-multi-version.json')
+      app.get '/packages/atom-2048', (request, response) ->
+        response.sendfile path.join(__dirname, 'fixtures', 'atom-2048.json')
 
       server =  http.createServer(app)
       server.listen(3000)
@@ -307,3 +309,14 @@ describe 'apm install', ->
 
         runs ->
           expect(callback.mostRecentCall.args[0]).toBeUndefined()
+
+    describe 'when a deprecated package name is specified', ->
+      it 'does not install the package', ->
+        callback = jasmine.createSpy('callback')
+        apm.run(['install', "atom-2048"], callback)
+
+        waitsFor 'waiting for install to complete', 600000, ->
+          callback.callCount is 1
+
+        runs ->
+          expect(callback.mostRecentCall.args[0]).toBeTruthy()

--- a/spec/search-spec.coffee
+++ b/spec/search-spec.coffee
@@ -21,7 +21,7 @@ describe 'apm search', ->
   afterEach ->
     server.close()
 
-  it 'lists the matching packages', ->
+  it 'lists the matching packages and excluded deprecated packages', ->
     callback = jasmine.createSpy('callback')
     apm.run(['search', 'duck'], callback)
 
@@ -33,6 +33,7 @@ describe 'apm search', ->
       expect(console.log.argsForCall[1][0]).toContain 'duckberg'
       expect(console.log.argsForCall[2][0]).toContain 'ducktales'
       expect(console.log.argsForCall[3][0]).toContain 'duckblur'
+      expect(console.log.argsForCall[4][0]).toBeUndefined()
 
   it "logs an error if the query is missing or empty", ->
     callback = jasmine.createSpy('callback')

--- a/spec/search-spec.coffee
+++ b/spec/search-spec.coffee
@@ -21,7 +21,7 @@ describe 'apm search', ->
   afterEach ->
     server.close()
 
-  it 'lists the matching packages and excluded deprecated packages', ->
+  it 'lists the matching packages and excludes deprecated packages', ->
     callback = jasmine.createSpy('callback')
     apm.run(['search', 'duck'], callback)
 

--- a/src/deprecated-packages.coffee
+++ b/src/deprecated-packages.coffee
@@ -1,0 +1,11 @@
+semver = require 'npm/node_modules/semver'
+deprecatedPackages = null
+
+exports.isDeprecatedPackage = (name, version) ->
+  deprecatedPackages ?= require('../deprecated-packages') ? {}
+  return false unless deprecatedPackages.hasOwnProperty(name)
+
+  deprecatedVersionRange = deprecatedPackages[name].version
+  return true unless deprecatedVersionRange
+
+  semver.valid(version) and semver.validRange(deprecatedVersionRange) and semver.satisfies(version, deprecatedVersionRange)

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -5,6 +5,7 @@ Command = require './command'
 config = require './apm'
 request = require './request'
 tree = require './tree'
+{isDeprecatedPackage} = require './deprecated-packages'
 
 module.exports =
 class Search extends Command
@@ -43,6 +44,7 @@ class Search extends Command
       else if response.statusCode is 200
         packages = body.filter (pack) -> pack.releases?.latest?
         packages = packages.map ({readme, metadata, downloads, stargazers_count}) -> _.extend({}, metadata, {readme, downloads, stargazers_count})
+        packages = packages.filter ({name, version}) -> not isDeprecatedPackage(name, version)
         callback(null, packages)
       else
         message = request.getErrorMessage(response, body)


### PR DESCRIPTION
Use a list of known packages with deprecations to prevent installation of packages not compatible with Atom 1.0

Only affects the `apm search` and `apm install` commands.

Refs https://github.com/atom/atom/issues/6867

/cc @benogle 