### PR TITLE
Revert "Use /usr/bin/env bash in hashbang"

### DIFF
--- a/bin/apm
+++ b/bin/apm
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
Reverts atom/apm#361

Alas, I'd hoped this would be a drop-in replacement, but it breaks installations with malformed `PATH`s.

Fixes https://github.com/atom/atom/issues/6985