### PR TITLE
[WIP] Add Service Dependency Hints / Metadata

### DIFF
--- a/spec/fixtures/autocomplete-superawesome.json
+++ b/spec/fixtures/autocomplete-superawesome.json
@@ -1,0 +1,17 @@
+{
+  "releases": {
+    "latest": "1.0.0"
+  },
+  "name": "autocomplete-superawesome",
+  "versions": {
+    "1.0.0": {
+      "dist": {
+        "tarball": "http://localhost:3000/tarball/test-module-1.0.0.tgz"
+      }
+    }
+  },
+  "services": {
+    "provides": ["supercomplete"],
+    "consumes": []
+  }
+}

--- a/spec/fixtures/service-delinter.json
+++ b/spec/fixtures/service-delinter.json
@@ -1,0 +1,22 @@
+{
+  "name": "delinter",
+  "versions": {
+    "latest": "1.0.2",
+    "1.0.2": "1.0.2",
+    "1.0.1": "1.0.1",
+    "1.0.0": "1.0.0"
+  },
+  "metadata": {
+    "name": "delinter",
+    "providers": {
+      "1.0.0": ["delinter-superawesome"],
+      "1.0.1": ["delinter-superawesome", "delinter-ludicrouslyawesome"],
+      "1.0.2": ["delinter-ludicrouslyawesome"]
+    },
+    "consumers": {
+      "1.0.0": ["delinter"],
+      "1.0.1": ["delinter", "delinter-cubed"],
+      "1.0.2": ["delinter-cubed"]
+    }
+  }
+}

--- a/spec/fixtures/service-supercomplete.json
+++ b/spec/fixtures/service-supercomplete.json
@@ -1,0 +1,22 @@
+{
+  "name": "supercomplete",
+  "versions": {
+    "latest": "1.2.3",
+    "1.2.2": "1.2.2",
+    "1.2.1": "1.2.1",
+    "1.2.0": "1.2.0",
+    "1.1.0": "1.1.0",
+    "1.0.0": "1.0.0"
+  },
+  "metadata": {
+    "name": "supercomplete",
+    "providers": {
+      "1.0.0": ["autocomplete-superawesome"],
+      "1.2.0": ["autocomplete-superawesome", "autocomplete-ludicrouslyawesome"]
+    },
+    "consumers": {
+      "1.0.0": ["supercomplete-plus"],
+      "1.2.0": ["supercomplete-plus", "supercomplete-squared"]
+    }
+  }
+}

--- a/spec/fixtures/services.json
+++ b/spec/fixtures/services.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "supercomplete",
+    "versions": {
+      "latest": "1.2.3",
+      "1.2.2": "1.2.2",
+      "1.2.1": "1.2.1",
+      "1.2.0": "1.2.0",
+      "1.1.0": "1.1.0",
+      "1.0.0": "1.0.0"
+    },
+    "metadata": {
+      "name": "supercomplete",
+      "providers": {
+        "1.0.0": ["autocomplete-superawesome"],
+        "1.2.0": ["autocomplete-superawesome", "autocomplete-ludicrouslyawesome"]
+      },
+      "consumers": {
+        "1.0.0": ["supercomplete-plus"],
+        "1.2.0": ["supercomplete-plus", "supercomplete-squared"]
+      }
+    }
+  },
+  {
+    "name": "delinter",
+    "versions": {
+      "latest": "1.0.2",
+      "1.0.2": "1.0.2",
+      "1.0.1": "1.0.1",
+      "1.0.0": "1.0.0"
+    },
+    "metadata": {
+      "name": "delinter",
+      "providers": {
+        "1.0.0": ["delinter-superawesome"],
+        "1.0.1": ["delinter-superawesome", "delinter-ludicrouslyawesome"],
+        "1.0.2": ["delinter-ludicrouslyawesome"]
+      },
+      "consumers": {
+        "1.0.0": ["delinter"],
+        "1.0.1": ["delinter", "delinter-cubed"],
+        "1.0.2": ["delinter-cubed"]
+      }
+    }
+  }
+]

--- a/spec/fixtures/supercomplete-plus.json
+++ b/spec/fixtures/supercomplete-plus.json
@@ -1,0 +1,17 @@
+{
+  "releases": {
+    "latest": "1.0.0"
+  },
+  "name": "supercomplete-plus",
+  "versions": {
+    "1.0.0": {
+      "dist": {
+        "tarball": "http://localhost:3000/tarball/test-module-1.0.0.tgz"
+      }
+    }
+  },
+  "services": {
+    "provides": [],
+    "consumes": ["supercomplete"]
+  }
+}

--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -55,6 +55,18 @@ describe 'apm install', ->
       app.get '/packages/atom-2048', (request, response) ->
         response.sendfile path.join(__dirname, 'fixtures', 'atom-2048.json')
 
+      # Services
+      app.get '/services', (request, response) ->
+        response.sendfile path.join(__dirname, 'fixtures', 'services.json')
+      app.get '/services/supercomplete', (request, response) ->
+        response.sendfile path.join(__dirname, 'fixtures', 'service-supercomplete.json')
+      app.get '/services/delinter', (request, response) ->
+        response.sendfile path.join(__dirname, 'fixtures', 'service-delinter.json')
+      app.get '/packages/autocomplete-superawesome', (request, response) ->
+        response.sendfile path.join(__dirname, 'fixtures', 'autocomplete-superawesome.json')
+      app.get '/packages/supercomplete-plus', (request, response) ->
+        response.sendfile path.join(__dirname, 'fixtures', 'supercomplete-plus.json')
+
       server =  http.createServer(app)
       server.listen(3000)
 
@@ -320,3 +332,16 @@ describe 'apm install', ->
 
         runs ->
           expect(callback.mostRecentCall.args[0]).toBeTruthy()
+
+    fdescribe 'when a package has a required service dependency', ->
+      it 'fails if no services are installed with a required service', ->
+        callback = jasmine.createSpy('callback')
+        apm.run(['install', "autocomplete-superawesome"], callback)
+
+        waitsFor 'waiting for install to complete', 600000, ->
+          callback.callCount is 1
+
+        runs ->
+          console.log 'hello'
+          console.log JSON.stringify(callback)
+          expect(callback.mostRecentCall.args[0]).toBeFalsy()


### PR DESCRIPTION
:rotating_light: WIP - Proposal, Do Not Merge Yet :rotating_light:

After discussions with @nathansobo, @maxbrunsfeld, @bolinfest, this PR will allow packages to express the `need` for packages _or_ the `desire` for packages that provide or consume a service with a specific service name.

## Goals

Allow packages to specify:

* There must be a package installed and activated that consumes a service with the name `x` for me to function at all. E.g. "I am `autocomplete-snippets`. If there is no package installed that consumes the `autocomplete` service, I cannot function".
* It would be nice if a package is installed and activated that consumes a service with the name `x` but my package can function without it. E.g. "I am `go-plus`. If there is no package installed that consumes the `autocomplete` service, I just won't provide autocomplete suggestions from gocode".
* There must be a package installed and activated that provides a service with the name `x` for me to function at all. E.g. "I am `linter-superawesome`. If there is no package installed that provides the `linter-helpers` service, I cannot function".
* It would be nice if a package is installed and activated that provides a service with the name `x` but my package can function without it. E.g. "I am `autocomplete-plus`. If there is no package installed that provides the `autocomplete` service, I can function just fine because i have SymbolProvider built-in".
* Allow a package to "hint" that a package is known to provide a particular service. I.e. "I am `autocomplete-hack`, and I know that `autocomplete-plus` provides the `autocomplete` service."
* Install package(s) that satisfy the service dependencies expressed, so that the package that provides or consumes said services can function correctly.

## Non-Goals

* This PR will not allow packages to specify a hard dependency on specific apm packages - no guarantee is made to packages that hint that a package satisfies their service dependency desires or needs
* This PR will not address the UI required to prompt a user to choose from package(s) which may match the service dependencies expressed (it will focus on the core APM changes required, which can then be built upon in `PackageManager`)

/cc @kevinsawicki @thedaniel @benogle @jlord 

This was formerly part of #385.

:rotating_light: WIP - Proposal, Do Not Merge Yet :rotating_light: