### PR TITLE
Add enable and disable commands

### DIFF
--- a/spec/disable-spec.coffee
+++ b/spec/disable-spec.coffee
@@ -5,12 +5,12 @@ CSON = require 'season'
 
 apm = require '../lib/apm-cli'
 
-describe 'apm enable', ->
+describe 'apm disable', ->
   beforeEach ->
     silenceOutput()
     spyOnToken()
 
-  it 'enables a disabled package', ->
+  it 'disables an enabled package', ->
     atomHome = temp.mkdirSync('apm-home-dir-')
     process.env.ATOM_HOME = atomHome
     callback = jasmine.createSpy('callback')
@@ -19,16 +19,14 @@ describe 'apm enable', ->
     CSON.writeFileSync configFilePath, '*':
       core:
         disabledPackages: [
-          "metrics"
           "vim-mode"
-          "exception-reporting"
           "file-icons"
         ]
 
     runs ->
-      apm.run(['enable', 'vim-mode', 'file-icons'], callback)
+      apm.run(['disable', 'metrics', 'exception-reporting'], callback)
 
-    waitsFor 'waiting for enable to complete', ->
+    waitsFor 'waiting for disable to complete', ->
       callback.callCount > 0
 
     runs ->
@@ -36,11 +34,13 @@ describe 'apm enable', ->
       expect(config).toEqual '*':
         core:
           disabledPackages: [
+            "vim-mode"
+            "file-icons"
             "metrics"
             "exception-reporting"
           ]
 
-  it 'does nothing if a package is already enabled', ->
+  it 'does nothing if a package is already disabled', ->
     atomHome = temp.mkdirSync('apm-home-dir-')
     process.env.ATOM_HOME = atomHome
     callback = jasmine.createSpy('callback')
@@ -49,14 +49,16 @@ describe 'apm enable', ->
     CSON.writeFileSync configFilePath, '*':
       core:
         disabledPackages: [
+          "vim-mode"
+          "file-icons"
           "metrics"
           "exception-reporting"
         ]
 
     runs ->
-      apm.run(['enable', 'vim-mode'], callback)
+      apm.run(['disable', 'vim-mode', 'metrics'], callback)
 
-    waitsFor 'waiting for enable to complete', ->
+    waitsFor 'waiting for disable to complete', ->
       callback.callCount > 0
 
     runs ->
@@ -64,6 +66,8 @@ describe 'apm enable', ->
       expect(config).toEqual '*':
         core:
           disabledPackages: [
+            "vim-mode"
+            "file-icons"
             "metrics"
             "exception-reporting"
           ]
@@ -74,9 +78,9 @@ describe 'apm enable', ->
     callback = jasmine.createSpy('callback')
 
     runs ->
-      apm.run(['enable', 'vim-mode'], callback)
+      apm.run(['disable', 'vim-mode'], callback)
 
-    waitsFor 'waiting for enable to complete', ->
+    waitsFor 'waiting for disable to complete', ->
       callback.callCount > 0
 
     runs ->
@@ -89,9 +93,9 @@ describe 'apm enable', ->
     callback = jasmine.createSpy('callback')
 
     runs ->
-      apm.run(['enable'], callback)
+      apm.run(['disable'], callback)
 
-    waitsFor 'waiting for enable to complete', ->
+    waitsFor 'waiting for disable to complete', ->
       callback.callCount > 0
 
     runs ->

--- a/spec/enable-spec.coffee
+++ b/spec/enable-spec.coffee
@@ -10,7 +10,7 @@ describe 'apm enable', ->
     silenceOutput()
     spyOnToken()
 
-  fit 'enables a disabled package', ->
+  it 'enables a disabled package', ->
     atomHome = temp.mkdirSync('apm-home-dir-')
     process.env.ATOM_HOME = atomHome
     callback = jasmine.createSpy('callback')
@@ -41,7 +41,59 @@ describe 'apm enable', ->
           ]
 
   it 'does nothing if a package is already enabled', ->
+    atomHome = temp.mkdirSync('apm-home-dir-')
+    process.env.ATOM_HOME = atomHome
+    callback = jasmine.createSpy('callback')
+    configFilePath = path.join(atomHome, 'config.cson')
+
+    CSON.writeFileSync configFilePath, '*':
+      core:
+        disabledPackages: [
+          "metrics"
+          "exception-reporting"
+        ]
+
+    runs ->
+      apm.run(['enable', 'vim-mode'], callback)
+
+    waitsFor 'waiting for enable to complete', ->
+      callback.callCount > 0
+
+    runs ->
+      config = CSON.readFileSync(configFilePath)
+      expect(config).toEqual '*':
+        core:
+          disabledPackages: [
+            "metrics"
+            "exception-reporting"
+          ]
 
   it 'produces an error if config.cson doesn\'t exist', ->
+    atomHome = temp.mkdirSync('apm-home-dir-')
+    process.env.ATOM_HOME = atomHome
+    callback = jasmine.createSpy('callback')
+
+    runs ->
+      apm.run(['enable', 'vim-mode'], callback)
+
+    waitsFor 'waiting for enable to complete', ->
+      callback.callCount > 0
+
+    runs ->
+      expect(console.error).toHaveBeenCalled()
+      expect(console.error.argsForCall[0][0].length).toBeGreaterThan 0
 
   it 'complains if user supplies no packages', ->
+    atomHome = temp.mkdirSync('apm-home-dir-')
+    process.env.ATOM_HOME = atomHome
+    callback = jasmine.createSpy('callback')
+
+    runs ->
+      apm.run(['enable'], callback)
+
+    waitsFor 'waiting for enable to complete', ->
+      callback.callCount > 0
+
+    runs ->
+      expect(console.error).toHaveBeenCalled()
+      expect(console.error.argsForCall[0][0].length).toBeGreaterThan 0

--- a/spec/enable-spec.coffee
+++ b/spec/enable-spec.coffee
@@ -26,12 +26,16 @@ describe 'apm enable', ->
         ]
 
     runs ->
-      apm.run(['enable', 'vim-mode', 'file-icons'], callback)
+      apm.run(['enable', 'vim-mode', 'not-installed', 'file-icons'], callback)
 
     waitsFor 'waiting for enable to complete', ->
       callback.callCount > 0
 
     runs ->
+      expect(console.log).toHaveBeenCalled()
+      expect(console.log.argsForCall[0][0]).toMatch /Not Disabled:\s*not-installed/
+      expect(console.log.argsForCall[1][0]).toMatch /Enabled:\s*vim-mode/
+
       config = CSON.readFileSync(configFilePath)
       expect(config).toEqual '*':
         core:
@@ -60,6 +64,9 @@ describe 'apm enable', ->
       callback.callCount > 0
 
     runs ->
+      expect(console.log).toHaveBeenCalled()
+      expect(console.log.argsForCall[0][0]).toMatch /Not Disabled:\s*vim-mode/
+
       config = CSON.readFileSync(configFilePath)
       expect(config).toEqual '*':
         core:

--- a/spec/enable-spec.coffee
+++ b/spec/enable-spec.coffee
@@ -1,0 +1,47 @@
+fs = require 'fs'
+path = require 'path'
+temp = require 'temp'
+CSON = require 'season'
+
+apm = require '../lib/apm-cli'
+
+describe 'apm enable', ->
+  beforeEach ->
+    silenceOutput()
+    spyOnToken()
+
+  fit 'enables a disabled package', ->
+    atomHome = temp.mkdirSync('apm-home-dir-')
+    process.env.ATOM_HOME = atomHome
+    callback = jasmine.createSpy('callback')
+    configFilePath = path.join(atomHome, 'config.cson')
+
+    CSON.writeFileSync configFilePath, '*':
+      core:
+        disabledPackages: [
+          "metrics"
+          "vim-mode"
+          "exception-reporting"
+          "ex-mode"
+        ]
+
+    runs ->
+      apm.run(['enable', 'vim-mode', 'ex-mode'], callback)
+
+    waitsFor 'waiting for enable to complete', ->
+      callback.callCount > 0
+
+    runs ->
+      config = CSON.readFileSync(configFilePath)
+      expect(config).toEqual '*':
+        core:
+          disabledPackages: [
+            "metrics"
+            "exception-reporting"
+          ]
+
+  it 'does nothing if a package is already enabled', ->
+
+  it 'produces an error if config.cson doesn\'t exist', ->
+
+  it 'complains if user supplies no packages', ->

--- a/spec/fixtures/test-module-three/package.json
+++ b/spec/fixtures/test-module-three/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-module-three",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "engines": {
+    "atom": "*"
+  }
+}

--- a/spec/fixtures/test-module-two/package.json
+++ b/spec/fixtures/test-module-two/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-module-two",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "engines": {
+    "atom": "*"
+  }
+}

--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -32,6 +32,7 @@ commandClasses = [
   require './dedupe'
   require './develop'
   require './docs'
+  require './enable'
   require './featured'
   require './init'
   require './install'

--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -31,6 +31,7 @@ commandClasses = [
   require './config'
   require './dedupe'
   require './develop'
+  require './disable'
   require './docs'
   require './enable'
   require './featured'

--- a/src/disable.coffee
+++ b/src/disable.coffee
@@ -5,6 +5,7 @@ yargs = require 'yargs'
 
 config = require './apm'
 Command = require './command'
+List = require './list'
 
 module.exports =
 class Disable extends Command
@@ -20,14 +21,23 @@ class Disable extends Command
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
 
+  getInstalledPackages: (callback) ->
+    options =
+      argv:
+        theme: false
+        bare: true
+
+    lister = new List()
+    lister.listBundledPackages options, (error, core_packages) ->
+      lister.listDevPackages options, (error, dev_packages) ->
+        lister.listUserPackages options, (error, user_packages) ->
+          callback(null, core_packages.concat(dev_packages, user_packages))
+
   run: (options) ->
     {callback} = options
     options = @parseOptions(options.commandArgs)
 
     packageNames = @packageNamesFromArgv(options.argv)
-    if packageNames.length is 0
-      callback("Please specify a package to disable")
-      return
 
     configFilePath = CSON.resolve(path.join(config.getAtomDirectory(), 'config'))
     unless configFilePath
@@ -40,17 +50,34 @@ class Disable extends Command
       callback "Failed to load `#{configFilePath}`: #{error.message}"
       return
 
-    keyPath = '*.core.disabledPackages'
-    disabledPackages = _.valueForKeyPath(settings, keyPath) ? []
-    result = _.union(disabledPackages, packageNames...)
-    _.setValueForKeyPath(settings, keyPath, result)
+    @getInstalledPackages (error, installedPackages) =>
+      return callback(error) if error
 
-    try
-      CSON.writeFileSync(configFilePath, settings)
-    catch error
-      callback "Failed to save `#{configFilePath}`: #{error.message}"
-      return
+      installedPackageNames = (pkg.name for pkg in installedPackages)
 
-    console.log "Disabled:\n  #{packageNames.join('\n  ')} "
-    @logSuccess()
-    callback()
+      # uninstalledPackages = (name for name in packageNames when !installedPackageNames[name])
+      uninstalledPackageNames = _.difference(packageNames, installedPackageNames)
+      if uninstalledPackageNames.length > 0
+        console.log "Not Installed:\n  #{uninstalledPackageNames.join('\n  ')}"
+
+      # only installed packages can be disabled
+      packageNames = _.difference(packageNames, uninstalledPackageNames)
+
+      if packageNames.length is 0
+        callback("Please specify a package to disable")
+        return
+
+      keyPath = '*.core.disabledPackages'
+      disabledPackages = _.valueForKeyPath(settings, keyPath) ? []
+      result = _.union(disabledPackages, packageNames...)
+      _.setValueForKeyPath(settings, keyPath, result)
+
+      try
+        CSON.writeFileSync(configFilePath, settings)
+      catch error
+        callback "Failed to save `#{configFilePath}`: #{error.message}"
+        return
+
+      console.log "Disabled:\n  #{packageNames.join('\n  ')}"
+      @logSuccess()
+      callback()

--- a/src/disable.coffee
+++ b/src/disable.coffee
@@ -1,0 +1,54 @@
+_ = require 'underscore-plus'
+path = require 'path'
+CSON = require 'season'
+yargs = require 'yargs'
+
+config = require './apm'
+Command = require './command'
+
+module.exports =
+class Disable extends Command
+  @commandNames: ['disable']
+
+  parseOptions: (argv) ->
+    options = yargs(argv).wrap(100)
+    options.usage """
+
+      Usage: apm disable [<package_name>]...
+
+      Disables the named package(s).
+    """
+    options.alias('h', 'help').describe('help', 'Print this usage message')
+
+  run: (options) ->
+    {callback} = options
+    options = @parseOptions(options.commandArgs)
+
+    packageNames = @packageNamesFromArgv(options.argv)
+    if packageNames.length is 0
+      callback("Please specify a package to disable")
+      return
+
+    configFilePath = CSON.resolve(path.join(config.getAtomDirectory(), 'config'))
+    unless configFilePath
+      callback("Could not find config.cson. Run Atom first?")
+      return
+
+    try
+      settings = CSON.readFileSync(configFilePath)
+    catch error
+      callback "Failed to load `#{configFilePath}`: #{error.message}"
+      return
+
+    keyPath = '*.core.disabledPackages'
+    disabledPackages = _.valueForKeyPath(settings, keyPath) or []
+    result = _.union(disabledPackages, packageNames...)
+    _.setValueForKeyPath(settings, keyPath, result)
+
+    try
+      CSON.writeFileSync(configFilePath, settings)
+    catch error
+      callback "Failed to save `#{configFilePath}`: #{error.message}"
+      return
+
+    callback()

--- a/src/disable.coffee
+++ b/src/disable.coffee
@@ -51,6 +51,6 @@ class Disable extends Command
       callback "Failed to save `#{configFilePath}`: #{error.message}"
       return
 
-    console.log "Disabled: #{packageNames.join(', ')} "
+    console.log "Disabled:\n  #{packageNames.join('\n  ')} "
     @logSuccess()
     callback()

--- a/src/disable.coffee
+++ b/src/disable.coffee
@@ -41,7 +41,7 @@ class Disable extends Command
       return
 
     keyPath = '*.core.disabledPackages'
-    disabledPackages = _.valueForKeyPath(settings, keyPath) or []
+    disabledPackages = _.valueForKeyPath(settings, keyPath) ? []
     result = _.union(disabledPackages, packageNames...)
     _.setValueForKeyPath(settings, keyPath, result)
 

--- a/src/disable.coffee
+++ b/src/disable.coffee
@@ -51,4 +51,6 @@ class Disable extends Command
       callback "Failed to save `#{configFilePath}`: #{error.message}"
       return
 
+    process.stdout.write "Disabled: #{packageNames.join(', ')} "
+    @logSuccess()
     callback()

--- a/src/disable.coffee
+++ b/src/disable.coffee
@@ -51,6 +51,6 @@ class Disable extends Command
       callback "Failed to save `#{configFilePath}`: #{error.message}"
       return
 
-    process.stdout.write "Disabled: #{packageNames.join(', ')} "
+    console.log "Disabled: #{packageNames.join(', ')} "
     @logSuccess()
     callback()

--- a/src/enable.coffee
+++ b/src/enable.coffee
@@ -24,14 +24,14 @@ class Enable extends Command
     {callback} = options
     options = @parseOptions(options.commandArgs)
 
-    configFilePath = CSON.resolve(path.join(config.getAtomDirectory(), 'config'))
-    unless configFilePath
-      callback("Could not find config.cson")
-      return
-
     packageNames = @packageNamesFromArgv(options.argv)
     if packageNames.length is 0
       callback("Please specify a package to enable")
+      return
+
+    configFilePath = CSON.resolve(path.join(config.getAtomDirectory(), 'config'))
+    unless configFilePath
+      callback("Could not find config.cson. Run Atom first?")
       return
 
     try

--- a/src/enable.coffee
+++ b/src/enable.coffee
@@ -51,6 +51,6 @@ class Enable extends Command
       callback "Failed to save `#{configFilePath}`: #{error.message}"
       return
 
-    console.log "Enabled: #{packageNames.join(', ')} "
+    console.log "Enabled:\n  #{packageNames.join('\n  ')} "
     @logSuccess()
     callback()

--- a/src/enable.coffee
+++ b/src/enable.coffee
@@ -1,0 +1,54 @@
+_ = require 'underscore-plus'
+path = require 'path'
+CSON = require 'season'
+yargs = require 'yargs'
+
+config = require './apm'
+Command = require './command'
+
+module.exports =
+class Enable extends Command
+  @commandNames: ['enable']
+
+  parseOptions: (argv) ->
+    options = yargs(argv).wrap(100)
+    options.usage """
+
+      Usage: apm enable [<package_name>]...
+
+      Enables the named package(s).
+    """
+    options.alias('h', 'help').describe('help', 'Print this usage message')
+
+  run: (options) ->
+    {callback} = options
+    options = @parseOptions(options.commandArgs)
+
+    configFilePath = CSON.resolve(path.join(config.getAtomDirectory(), 'config'))
+    unless configFilePath
+      callback("Could not find config.cson")
+      return
+
+    packageNames = @packageNamesFromArgv(options.argv)
+    if packageNames.length is 0
+      callback("Please specify a package to enable")
+      return
+
+    try
+      settings = CSON.readFileSync(configFilePath)
+    catch error
+      callback "Failed to load `#{configFilePath}`: #{error.message}"
+      return
+
+    keyPath = '*.core.disabledPackages'
+    disabledPackages = _.valueForKeyPath(settings, keyPath) or []
+    result = _.without(disabledPackages, packageNames...)
+    _.setValueForKeyPath(settings, keyPath, result)
+
+    try
+      CSON.writeFileSync(configFilePath, settings)
+    catch error
+      callback "Failed to save `#{configFilePath}`: #{error.message}"
+      return
+
+    callback()

--- a/src/enable.coffee
+++ b/src/enable.coffee
@@ -41,7 +41,7 @@ class Enable extends Command
       return
 
     keyPath = '*.core.disabledPackages'
-    disabledPackages = _.valueForKeyPath(settings, keyPath) or []
+    disabledPackages = _.valueForKeyPath(settings, keyPath) ? []
     result = _.without(disabledPackages, packageNames...)
     _.setValueForKeyPath(settings, keyPath, result)
 

--- a/src/enable.coffee
+++ b/src/enable.coffee
@@ -51,4 +51,6 @@ class Enable extends Command
       callback "Failed to save `#{configFilePath}`: #{error.message}"
       return
 
+    process.stdout.write "Enabled: #{packageNames.join(', ')} "
+    @logSuccess()
     callback()

--- a/src/enable.coffee
+++ b/src/enable.coffee
@@ -51,6 +51,6 @@ class Enable extends Command
       callback "Failed to save `#{configFilePath}`: #{error.message}"
       return
 
-    process.stdout.write "Enabled: #{packageNames.join(', ')} "
+    console.log "Enabled: #{packageNames.join(', ')} "
     @logSuccess()
     callback()


### PR DESCRIPTION
Addresses https://github.com/atom/apm/issues/358 and https://github.com/atom/atom/issues/5987.

There's some code duplication but that seems to be apm's style: commands and tests are mostly self-sufficient.  I wanted to make the new commands resemble the existing ones.