### PR TITLE
Use Travis container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,16 @@ notifications:
 node_js:
   - 0.10
 
-before_install: sudo apt-get install libgnome-keyring-dev
-
 git:
   depth: 10
 
 branches:
   only:
     - master
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libgnome-keyring-dev


### PR DESCRIPTION
Travis has started deprecating their old non-container infrastructure:
<img width="618" alt="build__964_-_atom_apm_-_travis_ci" src="https://cloud.githubusercontent.com/assets/823545/8942412/38250b6a-3543-11e5-8777-66d1b8f0cbc1.png">

This PR updates our Travis config to use the new container infrastructure. :tada: