### PR TITLE
Update to latest Electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "install": "node ./script/download-node.js",
     "test": "grunt test"
   },
+  "electronVersion": "0.30.2",
   "dependencies": {
     "asar-require": "0.2.0",
     "async": "~0.2.8",

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -52,7 +52,7 @@ module.exports =
     process.env.ATOM_REPOS_HOME ? path.join(@getHomeDirectory(), 'github')
 
   getNodeUrl: ->
-    process.env.ATOM_NODE_URL ? 'https://atom.io/download/atom-shell'
+    process.env.ATOM_NODE_URL ? 'https://atom.io/download/electron'
 
   getAtomPackagesUrl: ->
     process.env.ATOM_PACKAGES_URL ? "#{@getAtomApiUrl()}/packages"
@@ -61,7 +61,7 @@ module.exports =
     process.env.ATOM_API_URL ? 'https://atom.io/api'
 
   getNodeVersion: ->
-    process.env.ATOM_NODE_VERSION ? '0.22.0'
+    process.env.ATOM_NODE_VERSION ? '0.30.2'
 
   getNodeArch: ->
     switch process.platform

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -61,7 +61,7 @@ module.exports =
     process.env.ATOM_API_URL ? 'https://atom.io/api'
 
   getNodeVersion: ->
-    process.env.ATOM_NODE_VERSION ? '0.30.2'
+    process.env.ATOM_NODE_VERSION ? require('package.json').electronVersion
 
   getNodeArch: ->
     switch process.platform


### PR DESCRIPTION
Just tested this locally and this should fix the last issue in https://github.com/atom/atom/pull/7877 – apm now builds native modules correctly.

@zcbenz Should `ATOM_NODE_VERSION` and `ATOM_NODE_URL` be renamed to `ATOM_ELECTRON_VERSION` and `ATOM_ELECTRON_URL`, respectively?

/cc @thomasjo @kevinsawicki 