### PR TITLE
Use electron version from Atom's package.json

### DIFF
--- a/spec/clean-spec.coffee
+++ b/spec/clean-spec.coffee
@@ -30,7 +30,7 @@ describe 'apm clean', ->
     atomHome = temp.mkdirSync('apm-home-dir-')
     process.env.ATOM_HOME = atomHome
     process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
-    process.env.ATOM_NODE_VERSION = 'v0.10.3'
+    process.env.ATOM_ELECTRON_VERSION = 'v0.10.3'
 
     moduleDirectory = path.join(temp.mkdirSync('apm-test-module-'), 'test-module-with-dependencies')
     wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'test-module-with-dependencies'), moduleDirectory)

--- a/spec/clean-spec.coffee
+++ b/spec/clean-spec.coffee
@@ -29,7 +29,7 @@ describe 'apm clean', ->
 
     atomHome = temp.mkdirSync('apm-home-dir-')
     process.env.ATOM_HOME = atomHome
-    process.env.ATOM_NODE_URL = "http://localhost:3000/node"
+    process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
     process.env.ATOM_NODE_VERSION = 'v0.10.3'
 
     moduleDirectory = path.join(temp.mkdirSync('apm-test-module-'), 'test-module-with-dependencies')

--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -60,7 +60,7 @@ describe 'apm install', ->
 
       atomHome = temp.mkdirSync('apm-home-dir-')
       process.env.ATOM_HOME = atomHome
-      process.env.ATOM_NODE_URL = "http://localhost:3000/node"
+      process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
       process.env.ATOM_PACKAGES_URL = "http://localhost:3000/packages"
       process.env.ATOM_NODE_VERSION = 'v0.10.3'
 

--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -62,7 +62,7 @@ describe 'apm install', ->
       process.env.ATOM_HOME = atomHome
       process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
       process.env.ATOM_PACKAGES_URL = "http://localhost:3000/packages"
-      process.env.ATOM_NODE_VERSION = 'v0.10.3'
+      process.env.ATOM_ELECTRON_VERSION = 'v0.10.3'
 
     afterEach ->
       server.close()

--- a/spec/rebuild-spec.coffee
+++ b/spec/rebuild-spec.coffee
@@ -29,7 +29,7 @@ describe 'apm rebuild', ->
 
     atomHome = temp.mkdirSync('apm-home-dir-')
     process.env.ATOM_HOME = atomHome
-    process.env.ATOM_NODE_URL = "http://localhost:3000/node"
+    process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
     process.env.ATOM_PACKAGES_URL = "http://localhost:3000/packages"
     process.env.ATOM_NODE_VERSION = 'v0.10.3'
     process.env.ATOM_RESOURCE_PATH = temp.mkdirSync('atom-resource-path-')

--- a/spec/rebuild-spec.coffee
+++ b/spec/rebuild-spec.coffee
@@ -31,7 +31,7 @@ describe 'apm rebuild', ->
     process.env.ATOM_HOME = atomHome
     process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
     process.env.ATOM_PACKAGES_URL = "http://localhost:3000/packages"
-    process.env.ATOM_NODE_VERSION = 'v0.10.3'
+    process.env.ATOM_ELECTRON_VERSION = 'v0.10.3'
     process.env.ATOM_RESOURCE_PATH = temp.mkdirSync('atom-resource-path-')
 
   afterEach ->

--- a/spec/stars-spec.coffee
+++ b/spec/stars-spec.coffee
@@ -37,7 +37,7 @@ describe 'apm stars', ->
     atomHome = temp.mkdirSync('apm-home-dir-')
     process.env.ATOM_HOME = atomHome
     process.env.ATOM_API_URL = "http://localhost:3000"
-    process.env.ATOM_NODE_URL = "http://localhost:3000/node"
+    process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
     process.env.ATOM_PACKAGES_URL = "http://localhost:3000/packages"
     process.env.ATOM_NODE_VERSION = 'v0.10.3'
 

--- a/spec/stars-spec.coffee
+++ b/spec/stars-spec.coffee
@@ -39,7 +39,7 @@ describe 'apm stars', ->
     process.env.ATOM_API_URL = "http://localhost:3000"
     process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
     process.env.ATOM_PACKAGES_URL = "http://localhost:3000/packages"
-    process.env.ATOM_NODE_VERSION = 'v0.10.3'
+    process.env.ATOM_ELECTRON_VERSION = 'v0.10.3'
 
   afterEach ->
     server.close()

--- a/spec/upgrade-spec.coffee
+++ b/spec/upgrade-spec.coffee
@@ -32,7 +32,7 @@ describe "apm upgrade", ->
     process.env.ATOM_HOME = atomHome
     process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
     process.env.ATOM_PACKAGES_URL = "http://localhost:3000/packages"
-    process.env.ATOM_NODE_VERSION = 'v0.10.3'
+    process.env.ATOM_ELECTRON_VERSION = 'v0.10.3'
     process.env.ATOM_RESOURCE_PATH = atomApp
 
     fs.writeFileSync(path.join(atomApp, 'package.json'), JSON.stringify(version: '0.10.0'))

--- a/spec/upgrade-spec.coffee
+++ b/spec/upgrade-spec.coffee
@@ -30,7 +30,7 @@ describe "apm upgrade", ->
     atomApp = temp.mkdirSync('apm-app-dir-')
     packagesDir = path.join(atomHome, 'packages')
     process.env.ATOM_HOME = atomHome
-    process.env.ATOM_NODE_URL = "http://localhost:3000/node"
+    process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
     process.env.ATOM_PACKAGES_URL = "http://localhost:3000/packages"
     process.env.ATOM_NODE_VERSION = 'v0.10.3'
     process.env.ATOM_RESOURCE_PATH = atomApp

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -51,8 +51,8 @@ module.exports =
   getReposDirectory: ->
     process.env.ATOM_REPOS_HOME ? path.join(@getHomeDirectory(), 'github')
 
-  getNodeUrl: ->
-    process.env.ATOM_NODE_URL ? 'https://atom.io/download/atom-shell'
+  getElectronUrl: ->
+    process.env.ATOM_ELECTRON_URL ? process.env.ATOM_NODE_URL ? 'https://atom.io/download/atom-shell'
 
   getAtomPackagesUrl: ->
     process.env.ATOM_PACKAGES_URL ? "#{@getAtomApiUrl()}/packages"

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -52,6 +52,7 @@ module.exports =
     process.env.ATOM_REPOS_HOME ? path.join(@getHomeDirectory(), 'github')
 
   getElectronUrl: ->
+    # TODO Remove ATOM_NODE_URL env var support after a couple releases
     process.env.ATOM_ELECTRON_URL ? process.env.ATOM_NODE_URL ? 'https://atom.io/download/atom-shell'
 
   getAtomPackagesUrl: ->

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -60,7 +60,7 @@ module.exports =
   getAtomApiUrl: ->
     process.env.ATOM_API_URL ? 'https://atom.io/api'
 
-  getNodeArch: ->
+  getElectronArch: ->
     switch process.platform
       when 'darwin' then 'x64'
       when 'win32' then 'ia32'

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -60,9 +60,6 @@ module.exports =
   getAtomApiUrl: ->
     process.env.ATOM_API_URL ? 'https://atom.io/api'
 
-  getNodeVersion: ->
-    process.env.ATOM_NODE_VERSION ? '0.22.0'
-
   getNodeArch: ->
     switch process.platform
       when 'darwin' then 'x64'

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -66,3 +66,19 @@ class Command
       version.replace(/-.*$/, '')
     else
       version
+
+  loadInstalledAtomMetadata: (callback) ->
+    @getResourcePath (resourcePath) =>
+      try
+        {version, electronVersion} = require(path.join(resourcePath, 'package.json')) ? {}
+        version = @normalizeVersion(version)
+        @installedAtomVersion = version if semver.valid(version)
+
+      @electronVersion = process.env.ATOM_NODE_VERSION ? electronVersion ? '0.22.0'
+      callback()
+
+  getResourcePath: (callback) ->
+    if @resourcePath
+      process.nextTick => callback(@resourcePath)
+    else
+      config.getResourcePath (@resourcePath) => callback(@resourcePath)

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -77,7 +77,9 @@ class Command
         version = @normalizeVersion(version)
         @installedAtomVersion = version if semver.valid(version)
 
+      # TODO Remove ATOM_NODE_VERSION env var support after a couple releases
       @electronVersion = process.env.ATOM_ELECTRON_VERSION ? process.env.ATOM_NODE_VERSION ? electronVersion ? '0.22.0'
+
       callback()
 
   getResourcePath: (callback) ->

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -1,5 +1,7 @@
 child_process = require 'child_process'
+path = require 'path'
 _ = require 'underscore-plus'
+semver = require 'npm/node_modules/semver'
 config = require './apm'
 
 module.exports =

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -77,7 +77,7 @@ class Command
         version = @normalizeVersion(version)
         @installedAtomVersion = version if semver.valid(version)
 
-      @electronVersion = process.env.ATOM_NODE_VERSION ? electronVersion ? '0.22.0'
+      @electronVersion = process.env.ATOM_ELECTRON_VERSION ? process.env.ATOM_NODE_VERSION ? electronVersion ? '0.22.0'
       callback()
 
   getResourcePath: (callback) ->

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -1,5 +1,6 @@
 child_process = require 'child_process'
 _ = require 'underscore-plus'
+config = require './apm'
 
 module.exports =
 class Command

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -33,7 +33,7 @@ class Dedupe extends Command
 
   installNode: (callback) ->
     installNodeArgs = ['install']
-    installNodeArgs.push("--target=#{@electronVersion)}")
+    installNodeArgs.push("--target=#{@electronVersion}")
     installNodeArgs.push("--dist-url=#{config.getNodeUrl()}")
     installNodeArgs.push('--arch=ia32')
     installNodeArgs.push('--ensure')
@@ -71,7 +71,7 @@ class Dedupe extends Command
 
   forkDedupeCommand: (options, callback) ->
     dedupeArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'dedupe']
-    dedupeArgs.push("--target=#{@electronVersion)}")
+    dedupeArgs.push("--target=#{@electronVersion}")
     dedupeArgs.push('--arch=ia32')
     dedupeArgs.push('--silent') if options.argv.silent
     dedupeArgs.push('--quiet') if options.argv.quiet

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -34,7 +34,7 @@ class Dedupe extends Command
   installNode: (callback) ->
     installNodeArgs = ['install']
     installNodeArgs.push("--target=#{@electronVersion}")
-    installNodeArgs.push("--dist-url=#{config.getNodeUrl()}")
+    installNodeArgs.push("--dist-url=#{config.getElectronUrl()}")
     installNodeArgs.push('--arch=ia32')
     installNodeArgs.push('--ensure')
 

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -33,7 +33,7 @@ class Dedupe extends Command
 
   installNode: (callback) ->
     installNodeArgs = ['install']
-    installNodeArgs.push("--target=#{config.getNodeVersion()}")
+    installNodeArgs.push("--target=#{@electronVersion)}")
     installNodeArgs.push("--dist-url=#{config.getNodeUrl()}")
     installNodeArgs.push('--arch=ia32')
     installNodeArgs.push('--ensure')
@@ -71,7 +71,7 @@ class Dedupe extends Command
 
   forkDedupeCommand: (options, callback) ->
     dedupeArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'dedupe']
-    dedupeArgs.push("--target=#{config.getNodeVersion()}")
+    dedupeArgs.push("--target=#{@electronVersion)}")
     dedupeArgs.push('--arch=ia32')
     dedupeArgs.push('--silent') if options.argv.silent
     dedupeArgs.push('--quiet') if options.argv.quiet
@@ -100,6 +100,7 @@ class Dedupe extends Command
     @createAtomDirectories()
 
     commands = []
+    commands.push (callback) => @loadInstalledAtomMetadata(callback)
     commands.push (callback) => @installNode(callback)
     commands.push (callback) => @dedupeModules(options, callback)
     async.waterfall commands, callback

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -215,7 +215,7 @@ class Install extends Command
 
   forkInstallCommand: (options, callback) ->
     installArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'install']
-    installArgs.push("--target=#{@electronVersion)}")
+    installArgs.push("--target=#{@electronVersion}")
     installArgs.push("--arch=#{config.getNodeArch()}")
     installArgs.push('--silent') if options.argv.silent
     installArgs.push('--quiet') if options.argv.quiet
@@ -435,7 +435,7 @@ class Install extends Command
 
       buildArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'build']
       buildArgs.push(path.resolve(__dirname, '..', 'native-module'))
-      buildArgs.push("--target=#{@electronVersion)}")
+      buildArgs.push("--target=#{@electronVersion}")
       buildArgs.push("--arch=#{config.getNodeArch()}")
 
       if vsArgs = @getVisualStudioFlags()

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -525,7 +525,9 @@ class Install extends Command
     @createAtomDirectories()
 
     if options.argv.check
-      config.loadNpm (error, @npm) => @checkNativeBuildTools(callback)
+      config.loadNpm (error, @npm) =>
+        @loadInstalledAtomMetadata =>
+          @checkNativeBuildTools(callback)
       return
 
     @verbose = options.argv.verbose

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -517,15 +517,6 @@ class Install extends Command
 
     latestVersion
 
-  loadInstalledAtomVersion: (callback) ->
-    @getResourcePath (resourcePath) =>
-      try
-        {version} = require(path.join(resourcePath, 'package.json')) ? {}
-        version = @normalizeVersion(version)
-        @installedAtomVersion = version if semver.valid(version)
-        @electron
-      callback()
-
   run: (options) ->
     {callback} = options
     options = @parseOptions(options.commandArgs)

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -57,7 +57,7 @@ class Install extends Command
     installNodeArgs = ['install']
     installNodeArgs.push("--target=#{@electronVersion}")
     installNodeArgs.push("--dist-url=#{config.getElectronUrl()}")
-    installNodeArgs.push("--arch=#{config.getNodeArch()}")
+    installNodeArgs.push("--arch=#{config.getElectronArch()}")
     installNodeArgs.push("--ensure")
     installNodeArgs.push("--verbose") if @verbose
 
@@ -120,7 +120,7 @@ class Install extends Command
     installArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'install']
     installArgs.push(modulePath)
     installArgs.push("--target=#{@electronVersion}")
-    installArgs.push("--arch=#{config.getNodeArch()}")
+    installArgs.push("--arch=#{config.getElectronArch()}")
     installArgs.push('--silent') if options.argv.silent
     installArgs.push('--quiet') if options.argv.quiet
     installArgs.push('--production') if options.argv.production
@@ -216,7 +216,7 @@ class Install extends Command
   forkInstallCommand: (options, callback) ->
     installArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'install']
     installArgs.push("--target=#{@electronVersion}")
-    installArgs.push("--arch=#{config.getNodeArch()}")
+    installArgs.push("--arch=#{config.getElectronArch()}")
     installArgs.push('--silent') if options.argv.silent
     installArgs.push('--quiet') if options.argv.quiet
     installArgs.push('--production') if options.argv.production
@@ -436,7 +436,7 @@ class Install extends Command
       buildArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'build']
       buildArgs.push(path.resolve(__dirname, '..', 'native-module'))
       buildArgs.push("--target=#{@electronVersion}")
-      buildArgs.push("--arch=#{config.getNodeArch()}")
+      buildArgs.push("--arch=#{config.getElectronArch()}")
 
       if vsArgs = @getVisualStudioFlags()
         buildArgs.push(vsArgs)

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -56,7 +56,7 @@ class Install extends Command
   installNode: (callback) =>
     installNodeArgs = ['install']
     installNodeArgs.push("--target=#{@electronVersion}")
-    installNodeArgs.push("--dist-url=#{config.getNodeUrl()}")
+    installNodeArgs.push("--dist-url=#{config.getElectronUrl()}")
     installNodeArgs.push("--arch=#{config.getNodeArch()}")
     installNodeArgs.push("--ensure")
     installNodeArgs.push("--verbose") if @verbose

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -55,7 +55,7 @@ class Install extends Command
 
   installNode: (callback) =>
     installNodeArgs = ['install']
-    installNodeArgs.push("--target=#{config.getNodeVersion()}")
+    installNodeArgs.push("--target=#{@electronVersion}")
     installNodeArgs.push("--dist-url=#{config.getNodeUrl()}")
     installNodeArgs.push("--arch=#{config.getNodeArch()}")
     installNodeArgs.push("--ensure")
@@ -119,7 +119,7 @@ class Install extends Command
   installModule: (options, pack, modulePath, callback) ->
     installArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'install']
     installArgs.push(modulePath)
-    installArgs.push("--target=#{config.getNodeVersion()}")
+    installArgs.push("--target=#{@electronVersion}")
     installArgs.push("--arch=#{config.getNodeArch()}")
     installArgs.push('--silent') if options.argv.silent
     installArgs.push('--quiet') if options.argv.quiet
@@ -215,7 +215,7 @@ class Install extends Command
 
   forkInstallCommand: (options, callback) ->
     installArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'install']
-    installArgs.push("--target=#{config.getNodeVersion()}")
+    installArgs.push("--target=#{@electronVersion)}")
     installArgs.push("--arch=#{config.getNodeArch()}")
     installArgs.push('--silent') if options.argv.silent
     installArgs.push('--quiet') if options.argv.quiet
@@ -435,7 +435,7 @@ class Install extends Command
 
       buildArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'build']
       buildArgs.push(path.resolve(__dirname, '..', 'native-module'))
-      buildArgs.push("--target=#{config.getNodeVersion()}")
+      buildArgs.push("--target=#{@electronVersion)}")
       buildArgs.push("--arch=#{config.getNodeArch()}")
 
       if vsArgs = @getVisualStudioFlags()
@@ -461,12 +461,6 @@ class Install extends Command
 
     packages = fs.readFileSync(filePath, 'utf8')
     @sanitizePackageNames(packages.split(/\s/))
-
-  getResourcePath: (callback) ->
-    if @resourcePath
-      process.nextTick => callback(@resourcePath)
-    else
-      config.getResourcePath (@resourcePath) => callback(@resourcePath)
 
   buildModuleCache: (packageName, callback) ->
     packageDirectory = path.join(@atomPackagesDirectory, packageName)
@@ -529,6 +523,7 @@ class Install extends Command
         {version} = require(path.join(resourcePath, 'package.json')) ? {}
         version = @normalizeVersion(version)
         @installedAtomVersion = version if semver.valid(version)
+        @electron
       callback()
 
   run: (options) ->
@@ -576,7 +571,7 @@ class Install extends Command
 
     commands = []
     commands.push (callback) => config.loadNpm (error, @npm) => callback()
-    commands.push (callback) => @loadInstalledAtomVersion(callback)
+    commands.push (callback) => @loadInstalledAtomMetadata(callback)
     packageNames.forEach (packageName) ->
       commands.push (callback) -> installPackage(packageName, callback)
     async.waterfall(commands, callback)

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -41,7 +41,7 @@ class Rebuild extends Command
         process.stdout.write 'Rebuilding modules '
 
         rebuildArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'rebuild']
-        rebuildArgs.push("--target=#{config.getNodeVersion()}")
+        rebuildArgs.push("--target=#{@electronVersion)}")
         rebuildArgs.push("--arch=#{config.getNodeArch()}")
         rebuildArgs = rebuildArgs.concat(options.argv._)
 

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -41,7 +41,7 @@ class Rebuild extends Command
         process.stdout.write 'Rebuilding modules '
 
         rebuildArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'rebuild']
-        rebuildArgs.push("--target=#{@electronVersion)}")
+        rebuildArgs.push("--target=#{@electronVersion}")
         rebuildArgs.push("--arch=#{config.getNodeArch()}")
         rebuildArgs = rebuildArgs.concat(options.argv._)
 

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -44,7 +44,7 @@ class Rebuild extends Command
       config.getUserConfigPath()
       'rebuild'
       "--target=#{@electronVersion}"
-      "--arch=#{config.getNodeArch()}"
+      "--arch=#{config.getElectronArch()}"
     ]
     rebuildArgs = rebuildArgs.concat(options.argv._)
 

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -28,27 +28,40 @@ class Rebuild extends Command
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
 
+  installNode: (callback) ->
+    config.loadNpm (error, npm) ->
+      install = new Install()
+      install.npm = npm
+      install.loadInstalledAtomMetadata -> install.installNode(callback)
+
+  forkNpmRebuild: (options, callback) ->
+    process.stdout.write 'Rebuilding modules '
+
+    rebuildArgs = [
+      '--globalconfig'
+      config.getGlobalConfigPath()
+      '--userconfig'
+      config.getUserConfigPath()
+      'rebuild'
+      "--target=#{@electronVersion}"
+      "--arch=#{config.getNodeArch()}"
+    ]
+    rebuildArgs = rebuildArgs.concat(options.argv._)
+
+    env = _.extend({}, process.env, HOME: @atomNodeDirectory)
+    env.USERPROFILE = env.HOME if config.isWin32()
+
+    @fork(@atomNpmPath, rebuildArgs, {env}, callback)
+
   run: (options) ->
     {callback} = options
     options = @parseOptions(options.commandArgs)
 
-    config.loadNpm (error, npm) =>
-      install = new Install()
-      install.npm = npm
-      install.installNode (error) =>
+    @loadInstalledAtomMetadata =>
+      @installNode (error) =>
         return callback(error) if error?
 
-        process.stdout.write 'Rebuilding modules '
-
-        rebuildArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'rebuild']
-        rebuildArgs.push("--target=#{@electronVersion}")
-        rebuildArgs.push("--arch=#{config.getNodeArch()}")
-        rebuildArgs = rebuildArgs.concat(options.argv._)
-
-        env = _.extend({}, process.env, HOME: @atomNodeDirectory)
-        env.USERPROFILE = env.HOME if config.isWin32()
-
-        @fork @atomNpmPath, rebuildArgs, {env}, (code, stderr='') =>
+        @forkNpmRebuild options, (code, stderr='') =>
           if code is 0
             @logSuccess()
             callback()

--- a/src/upgrade.coffee
+++ b/src/upgrade.coffee
@@ -68,12 +68,7 @@ class Upgrade extends Command
         @installedAtomVersion = version if semver.valid(version)
         callback()
     else
-      config.getResourcePath (resourcePath) =>
-        try
-          {version} = require(path.join(resourcePath, 'package.json')) ? {}
-          version = @normalizeVersion(version)
-          @installedAtomVersion = version if semver.valid(version)
-        callback()
+      @loadInstalledAtomMetadata(callback)
 
   getLatestVersion: (pack, callback) ->
     requestSettings =


### PR DESCRIPTION
This pulls the `electronVersion` from Atom's `package.json` so the version doesn't need to be bumped  in this project for new versions.

@thomasjo and @mnquintana this is my take on what #409 is trying to do. I am totally onboard with moving the version configuration out of this repository and into atom/atom. I'm cautious to make upgrading to node 0.12 part of this though since I'd like to de-tangle upgrading the node version bundled with apm from upgrading Atom to using the latest Electron.

Refs #409