### PR TITLE
Upgrade to node 0.10.40

### DIFF
--- a/script/download-node.js
+++ b/script/download-node.js
@@ -110,7 +110,7 @@ var downloadNode = function(version, done) {
   }
 };
 
-downloadNode('v0.10.35', function(error) {
+downloadNode('v0.10.40', function(error) {
   if (error != null) {
     console.error('Failed to download node', error);
     return process.exit(1);


### PR DESCRIPTION
There is work in progress to go to node 0.12, but in the meantime this bumps apm to the latest `0.10.x` build for security fixes.

Refs atom/atom#8395