### PR TITLE
upgrades yargs dependency to ^3.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "underscore-plus": "1.x",
     "wordwrap": "0.0.2",
     "wrench": "~1.5.1",
-    "yargs": "3.19.0"
+    "yargs": "^3.23.0"
   },
   "devDependencies": {
     "jasmine-focused": ">=1.0.7 <2.0",


### PR DESCRIPTION
`yargs@3.23.0` eliminates the dependency on spawn-sync, to prevent regressions like we had last week yargs now has:

windows testing via AppVeyor: https://ci.appveyor.com/project/bcoe/yargs

_and_

OSX testing via Travis: https://travis-ci.org/bcoe/yargs
