### PR TITLE
Remove fallback electron version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom-package-manager",
   "description": "Atom package manager",
-  "version": "1.0.5",
+  "version": "1.0.6-0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -79,9 +79,15 @@ class Command
         @installedAtomVersion = version if semver.valid(version)
 
       # TODO Remove ATOM_NODE_VERSION env var support after a couple releases
-      @electronVersion = process.env.ATOM_ELECTRON_VERSION ? process.env.ATOM_NODE_VERSION ? electronVersion ? '0.22.0'
+      @electronVersion = process.env.ATOM_ELECTRON_VERSION ? process.env.ATOM_NODE_VERSION ? electronVersion
 
       callback()
+
+  assertElectronVersionDefined: (callback) ->
+    if @electronVersion?
+      callback()
+    else
+      callback("Could not determine electron version")
 
   getResourcePath: (callback) ->
     if @resourcePath

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -101,6 +101,7 @@ class Dedupe extends Command
 
     commands = []
     commands.push (callback) => @loadInstalledAtomMetadata(callback)
+    commands.push (callback) => @assertElectronVersionDefined(callback)
     commands.push (callback) => @installNode(callback)
     commands.push (callback) => @dedupeModules(options, callback)
     async.waterfall commands, callback

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -527,6 +527,7 @@ class Install extends Command
     commands = []
     commands.push (callback) => config.loadNpm (error, @npm) => callback()
     commands.push (callback) => @loadInstalledAtomMetadata(callback)
+    commands.push (callback) => @assertElectronVersionDefined(callback)
     packageNames.forEach (packageName) ->
       commands.push (callback) -> installPackage(packageName, callback)
     async.waterfall(commands, callback)

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -1,5 +1,6 @@
 path = require 'path'
 
+async = require 'async'
 _ = require 'underscore-plus'
 yargs = require 'yargs'
 
@@ -61,8 +62,11 @@ class Rebuild extends Command
     {callback} = options
     options = @parseOptions(options.commandArgs)
 
-    config.loadNpm (error, @npm) =>
-      @loadInstalledAtomMetadata =>
+    async.waterfall([
+      (callback) => config.loadNpm((error, @npm) => callback(error)),
+      (callback) => @loadInstalledAtomMetadata(callback),
+      (callback) => @assertElectronVersionDefined(callback),
+      (callback) =>
         @installNode (error) =>
           return callback(error) if error?
 
@@ -73,3 +77,4 @@ class Rebuild extends Command
             else
               @logFailure()
               callback(stderr)
+    ], callback)


### PR DESCRIPTION
CI was failing because `apm` was building Atom's native modules against the wrong version of Electron. The `ATOM_ELECTRON_VERSION` environment variable was not set, and `/Applications/Atom.app` was not present, so `apm` was silently falling back on version `0.22.0`.

This removes that fallback version, and makes `apm install` fail if it can't find the version of electron to build against.