### PR TITLE
Use bundled node in `apm rebuild`

### DIFF
--- a/spec/fixtures/package-with-native-deps/package.json
+++ b/spec/fixtures/package-with-native-deps/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-module",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "engines": {
+    "atom": "*"
+  },
+  "dependencies": {
+    "native-dep": "./node_modules/native-dep"
+  }
+}

--- a/spec/rebuild-spec.coffee
+++ b/spec/rebuild-spec.coffee
@@ -8,7 +8,7 @@ wrench = require 'wrench'
 apm = require '../lib/apm-cli'
 
 describe 'apm rebuild', ->
-  [server] = []
+  [server, originalPathEnv] = []
 
   beforeEach ->
     spyOnToken()
@@ -34,12 +34,16 @@ describe 'apm rebuild', ->
     process.env.ATOM_ELECTRON_VERSION = 'v0.10.3'
     process.env.ATOM_RESOURCE_PATH = temp.mkdirSync('atom-resource-path-')
 
+    originalPathEnv = process.env.PATH
+    process.env.PATH = ""
+
   afterEach ->
     server.close()
+    process.env.PATH = originalPathEnv
 
   it "rebuilds all modules when no module names are specified", ->
-    packageToRebuild = temp.mkdirSync('apm-test-package-')
-    fs.writeFileSync(path.join(packageToRebuild, 'package.json'), JSON.stringify(name: 'test', version: '1.0.0'))
+    packageToRebuild = path.join(__dirname, 'fixtures/package-with-native-deps')
+
     process.chdir(packageToRebuild)
     callback = jasmine.createSpy('callback')
     apm.run(['rebuild'], callback)
@@ -51,11 +55,11 @@ describe 'apm rebuild', ->
       expect(callback.mostRecentCall.args[0]).toBeUndefined()
 
   it "rebuilds the specified modules", ->
-    packageToRebuild = temp.mkdirSync('apm-test-package-')
-    fs.writeFileSync(path.join(packageToRebuild, 'package.json'), JSON.stringify(name: 'test', version: '1.0.0'))
+    packageToRebuild = path.join(__dirname, 'fixtures/package-with-native-deps')
+
     process.chdir(packageToRebuild)
     callback = jasmine.createSpy('callback')
-    apm.run(['rebuild', 'foo'], callback)
+    apm.run(['rebuild', 'native-dep'], callback)
 
     waitsFor 'waiting for rebuild to complete', 600000, ->
       callback.callCount is 1

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -48,8 +48,12 @@ class Rebuild extends Command
     ]
     rebuildArgs = rebuildArgs.concat(options.argv._)
 
+    if vsArgs = @getVisualStudioFlags()
+      rebuildArgs.push(vsArgs)
+
     env = _.extend({}, process.env, HOME: @atomNodeDirectory)
     env.USERPROFILE = env.HOME if config.isWin32()
+    @addBuildEnvVars(env)
 
     @fork(@atomNpmPath, rebuildArgs, {env}, callback)
 
@@ -57,14 +61,15 @@ class Rebuild extends Command
     {callback} = options
     options = @parseOptions(options.commandArgs)
 
-    @loadInstalledAtomMetadata =>
-      @installNode (error) =>
-        return callback(error) if error?
+    config.loadNpm (error, @npm) =>
+      @loadInstalledAtomMetadata =>
+        @installNode (error) =>
+          return callback(error) if error?
 
-        @forkNpmRebuild options, (code, stderr='') =>
-          if code is 0
-            @logSuccess()
-            callback()
-          else
-            @logFailure()
-            callback(stderr)
+          @forkNpmRebuild options, (code, stderr='') =>
+            if code is 0
+              @logSuccess()
+              callback()
+            else
+              @logFailure()
+              callback(stderr)


### PR DESCRIPTION
We now run `apm rebuild` from within Atom to rebuild incompatible packages. Unfortunately, it's breaking unless you launched Atom from the command line with a `PATH` that happens to contain a valid `node` executable. This changes the `rebuild` command to use the bundled `node`, just like we do for `apm install`.

Refs https://github.com/atom/atom/issues/8837