### PR TITLE
make apm look for proxy env variables if not already in the config

### DIFF
--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -50,7 +50,7 @@ class Dedupe extends Command
       env.NODE_TLS_REJECT_UNAUTHORIZED = 0 unless useStrictSsl
 
       # Pass through configured proxy to node-gyp
-      proxy = npm.config.get('https-proxy') or npm.config.get('proxy')
+      proxy = npm.config.get('https-proxy') or npm.config.get('proxy') or env.HTTPS_PROXY or env.HTTP_PROXY
       installNodeArgs.push("--proxy=#{proxy}") if proxy
 
       @fork @atomNodeGypPath, installNodeArgs, {env, cwd: @atomDirectory}, (code, stderr='', stdout='') ->

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -72,7 +72,7 @@ class Install extends Command
     env.NODE_TLS_REJECT_UNAUTHORIZED = 0 unless useStrictSsl
 
     # Pass through configured proxy to node-gyp
-    proxy = @npm.config.get('https-proxy') or @npm.config.get('proxy')
+    proxy = @npm.config.get('https-proxy') or @npm.config.get('proxy') or env.HTTPS_PROXY or env.HTTP_PROXY
     installNodeArgs.push("--proxy=#{proxy}") if proxy
 
     opts = {env, cwd: @atomDirectory}

--- a/src/request.coffee
+++ b/src/request.coffee
@@ -11,7 +11,7 @@ loadNpm = (callback) ->
 
 configureRequest = (requestOptions, callback) ->
   loadNpm ->
-    requestOptions.proxy ?= npm.config.get('https-proxy') or npm.config.get('proxy')
+    requestOptions.proxy ?= npm.config.get('https-proxy') or npm.config.get('proxy') or process.env.HTTPS_PROXY or process.env.HTTP_PROXY
     requestOptions.strictSSL ?= npm.config.get('strict-ssl')
 
     # Bump request timeout on CI to 30 minutes


### PR DESCRIPTION
as issue #398 requested I've made it so that npm looks for the environment variables HTTPS_PROXY and HTTP_PROXY to use if the proxy is not set within the config file. 

when setting my HTTPS_PROXY variable to http://proxy.com:8080 it is picked up by apm and added to the request as show in below screenshot:
![screenshot from 2015-10-10 15 36 55](https://cloud.githubusercontent.com/assets/1271360/10411664/f5f62f92-6f64-11e5-90c1-2603e854b258.png)