### PR TITLE
Upgrade to Node v4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ notifications:
     on_failure: change
 
 node_js:
-  - 0.10
+  - stable
+  - v4.2
+  - v0.10
 
 git:
   depth: 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ notifications:
     on_success: never
     on_failure: change
 
+env:
+  global:
+    - CXX=g++-4.8
+
 node_js:
   - stable
   - v4.2
@@ -21,5 +25,8 @@ sudo: false
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
       - libgnome-keyring-dev
+      - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ env:
     - CXX=g++-4.8
 
 node_js:
-  - stable
   - v4.2
-  - v0.10
 
 git:
   depth: 10

--- a/bin/apm
+++ b/bin/apm
@@ -25,4 +25,4 @@ done
 
 binDir=`pwd -P`
 builtin cd "$initialCwd"
-"$binDir/$nodeBin" --harmony_collections "$binDir/../lib/cli.js" "$@"
+"$binDir/$nodeBin" "$binDir/../lib/cli.js" "$@"

--- a/bin/apm.cmd
+++ b/bin/apm.cmd
@@ -1,6 +1,5 @@
 @IF EXIST "%~dp0\node.exe" (
-  "%~dp0\node.exe" --harmony_collections "%~dp0/../lib/cli.js" %*
+  "%~dp0\node.exe" "%~dp0/../lib/cli.js" %*
 ) ELSE (
-  node.exe --harmony_collections "%~dp0/../lib/cli.js" %*
+  node.exe "%~dp0/../lib/cli.js" %*
 )
-

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "keytar": "^3.0",
     "mv": "2.0.0",
     "ncp": "~0.5.1",
-    "npm": "2.13.3",
+    "npm": "2.14.7",
     "open": "0.0.4",
     "plist": "git+https://github.com/nathansobo/node-plist.git",
     "q": "~0.9.7",

--- a/script/download-node.js
+++ b/script/download-node.js
@@ -110,7 +110,7 @@ var downloadNode = function(version, done) {
   }
 };
 
-downloadNode('v4.2.0', function(error) {
+downloadNode('v4.2.1', function(error) {
   if (error != null) {
     console.error('Failed to download node', error);
     return process.exit(1);

--- a/script/download-node.js
+++ b/script/download-node.js
@@ -110,7 +110,7 @@ var downloadNode = function(version, done) {
   }
 };
 
-downloadNode('v0.10.40', function(error) {
+downloadNode('v4.2.0', function(error) {
   if (error != null) {
     console.error('Failed to download node', error);
     return process.exit(1);


### PR DESCRIPTION
I reckon it's about time to head for greener pastures — Node v4. Ensuring apm runs on v4 should help @jlord with getting Atom to run on ARM machines. In addition Node v4 has all the performance improvements, ES6 support, bug fixes, etc. that were added to io.js.

I experimented with bumping npm to v3 (3.3.6) but that proved less trivial due to the removal(?) of `peerDependencies`, so that will require more changes, and testing.

Note that I also bumped npm to v2.14.7 (latest stable v2 version as of writing this); I can easily yank that change if someone wants to keep the changeset here as minimal as possible.

/cc @atom/feedback 

---
Supersedes #430
Refs https://github.com/atom/atom/issues/7822