### PR TITLE
Update documentation on proxy usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,13 @@ file:
 strict-ssl = false
 ```
 
-If you are using a proxy you can configure `apm` to use it by setting the
-`https-proxy` config in your `~/.atom/.apmrc` file like so:
+If you are using a proxy you can configure `apm` to use it by either:
+
+* Using apm to add the new configuration item:
+
+```apm config set https-proxy https://9.0.2.1:0```
+
+* Adding the `https-proxy` configuration item to the `~/.atom/.apmrc` file:
 
 ```
 https-proxy = https://9.0.2.1:0

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 Discover and install Atom packages powered by [atom.io](https://atom.io)
 
-You can configure apm via a `~/.atom/.apmrc` file similarly to
-[npm config](https://docs.npmjs.com/misc/config).
+You can configure apm by using the `apm config` command line option (recommended) or by manually
+editing the `~/.atom/.apmrc` file as per the [npm config](https://docs.npmjs.com/misc/config).
 
 ## Relation to npm
 
@@ -49,25 +49,20 @@ a package to [atom.io](https://atom.io).
 ## Behind a firewall?
 
 If you are behind a firewall and seeing SSL errors when installing packages
-you can disable strict SSL by putting the following in your `~/.atom/.apmrc`
-file:
+you can disable strict SSL by running:
 
 ```
-strict-ssl = false
+apm config set strict-ssl false
 ```
 
-If you are using a proxy you can configure `apm` to use it by either:
+## Using a proxy?
 
-* Using apm to add the new configuration item:
+If you are using a HTTP(S) proxy you can configure `apm` to use it by running:
 
 ```apm config set https-proxy https://9.0.2.1:0```
 
-* Adding the `https-proxy` configuration item to the `~/.atom/.apmrc` file:
-
-```
-https-proxy = https://9.0.2.1:0
-```
-
 You can run `apm config get https-proxy` to verify it has been set correctly.
+
+## Viewing configuration
 
 You can also run `apm config list` to see all the custom config settings.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ apm config set strict-ssl false
 
 If you are using a HTTP(S) proxy you can configure `apm` to use it by running:
 
-```apm config set https-proxy https://9.0.2.1:0```
+```
+apm config set https-proxy https://9.0.2.1:0
+```
 
 You can run `apm config get https-proxy` to verify it has been set correctly.
 


### PR DESCRIPTION
Changed the README.md file to suggest using the apm command line tool to set the proxy configuration item rather than manually editing the .apmrc file.

Manually editing the ~/.atom/.apmrc file doesn't work if you run Atom on Windows by downloading the zip, extracting it and running it from a directory. In this case, the ~/.atom/.apmrc file is overwritten every time the apm command is executed. However, running the command line persists the changes successfully.