### PR TITLE
Check the keychain for the token before falling back to ATOM_ACCESS_TOKEN.

### DIFF
--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -17,11 +17,11 @@ module.exports =
   # callback - A function to call with an error as the first argument and a
   #            string token as the second argument.
   getToken: (callback) ->
-    if token = process.env.ATOM_ACCESS_TOKEN
+    if token = keytar.findPassword(tokenName)
       callback(null, token)
       return
 
-    if token = keytar.findPassword(tokenName)
+    if token = process.env.ATOM_ACCESS_TOKEN
       callback(null, token)
       return
 


### PR DESCRIPTION
Otherwise auth failures get confusing: we’d keep updating the token
stored in the keychain when the real problem was that `ATOM_ACCESS_TOKEN`
was out of date. See #505.