### PR TITLE
Upgrade grunt-coffeelint to 0.0.15 

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "grunt-cli": "~0.1.8",
     "grunt-shell": "~0.2.2",
     "express": "~3.2.3",
-    "grunt-coffeelint": "0.0.13",
+    "grunt-coffeelint": "0.0.15",
     "coffee-script": "^1.8.0"
   }
 }


### PR DESCRIPTION
With a clean checkout I was getting the error:

    Running "coffee:glob_to_multiple" (coffee) task
    >> 41 files created.
    Warning: Task "coffeelint" not found. Use --force to continue.
    Aborted due to warnings.
    npm WARN grunt-coffeelint@0.0.13 requires a peer of coffeelint@^1 but none was installed.

Upgrading the grunt-coffeelint package from 0.0.13 to 0.0.15 made this go away.