### PR TITLE
Ensure callback to Command::spawn is only called once

### DIFF
--- a/spec/command-spec.coffee
+++ b/spec/command-spec.coffee
@@ -1,0 +1,19 @@
+Command = require '../lib/command'
+
+describe "Command", ->
+  describe "::spawn", ->
+    it "only calls the callback once if the spawned program fails", ->
+      exited = false
+      callbackCount = 0
+
+      command = new Command
+      child = command.spawn "thisisafakecommand", [], ->
+        callbackCount++
+      child.once "close", ->
+        exited = true
+
+      waitsFor ->
+        exited
+
+      runs ->
+        expect(callbackCount).toEqual 1

--- a/spec/test-spec.coffee
+++ b/spec/test-spec.coffee
@@ -51,6 +51,7 @@ describe "apm test", ->
         stderr:
           on: ->
         on: atomReturnFn
+        removeListener: -> # no op
       apm.run(['test'], callback)
 
     describe 'successfully', ->

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -28,10 +28,15 @@ class Command
       else
         errorChunks.push(chunk)
 
-    spawned.on 'error', (error) ->
-      callback(error, Buffer.concat(errorChunks).toString(), Buffer.concat(outputChunks).toString())
-    spawned.on 'close', (code) ->
-      callback(code, Buffer.concat(errorChunks).toString(), Buffer.concat(outputChunks).toString())
+    onChildExit = (errorOrExitCode) ->
+      spawned.removeListener 'error', onChildExit
+      spawned.removeListener 'close', onChildExit
+      callback?(errorOrExitCode, Buffer.concat(errorChunks).toString(), Buffer.concat(outputChunks).toString())
+
+    spawned.on 'error', onChildExit
+    spawned.on 'close', onChildExit
+
+    spawned
 
   fork: (script, args, remaining...) ->
     args.unshift(script)


### PR DESCRIPTION
If a process spawned with `Command::spawn` exited with an error, we were finding that both `on("error", ...)` and `on("close", ...)` were being called, resulting in the callback to `spawn` being called more than once.

Signed-off-by: Katrina Uychaco @kuychaco 