### PR TITLE
Remove harmony collections from node options

### DIFF
--- a/bin/apm
+++ b/bin/apm
@@ -25,4 +25,4 @@ done
 
 binDir=`pwd -P`
 builtin cd "$initialCwd"
-"$binDir/$nodeBin" --harmony_collections "$binDir/../lib/cli.js" "$@"
+"$binDir/$nodeBin" "$binDir/../lib/cli.js" "$@"

--- a/bin/apm.cmd
+++ b/bin/apm.cmd
@@ -1,6 +1,6 @@
 @IF EXIST "%~dp0\node.exe" (
-  "%~dp0\node.exe" --harmony_collections "%~dp0/../lib/cli.js" %*
+  "%~dp0\node.exe" "%~dp0/../lib/cli.js" %*
 ) ELSE (
-  node.exe --harmony_collections "%~dp0/../lib/cli.js" %*
+  node.exe "%~dp0/../lib/cli.js" %*
 )
 


### PR DESCRIPTION
This subject arises in the following issues:
#449
#481 
#514 

Here are two articles backing up how this is unnecessary.

Harmony flag is no longer needed in Node 4
https://nodejs.org/en/blog/weekly-updates/weekly-update.2015-08-07/

Harmony flag is not needed in node v4
https://iojs.org/en/es6.html

By the way, my build environment breaks as a result of these flags,
```
D:\Users\Cole\Desktop\atom>"script\build" --install-dir ..\atom-install --build-dir ..\atom-build
Node: v4.3.2
npm: v2.13.3
Python: v2.7.9
Installing build modules...
=> Took 5360ms.

Installing apm...
=> Took 1013ms.

Deleting old packages...
node.exe: bad option: --harmony_collections
```