### PR TITLE
Output package installation information when using --json

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -69,6 +69,13 @@ class Command
       @logFailure()
       callback("#{stdout}\n#{stderr}".trim())
 
+  logCommandResultsIfFail: (callback, code, stderr='', stdout='') =>
+    if code is 0
+      callback()
+    else
+      @logFailure()
+      callback("#{stdout}\n#{stderr}".trim())
+
   normalizeVersion: (version) ->
     if typeof version is 'string'
       # Remove commit SHA suffix

--- a/src/develop.coffee
+++ b/src/develop.coffee
@@ -59,10 +59,13 @@ class Develop extends Command
     config.getSetting 'git', (command) =>
       command ?= 'git'
       args = ['clone', '--recursive', repoUrl, packageDirectory]
-      process.stdout.write "Cloning #{repoUrl} "
+      process.stdout.write "Cloning #{repoUrl} " unless options.argv.json
       git.addGitToEnv(process.env)
       @spawn command, args, (args...) =>
-        @logCommandResults(callback, args...)
+        if options.argv.json
+          @logCommandResultsIfFail(callback, args...)
+        else
+          @logCommandResults(callback, args...)
 
   installDependencies: (packageDirectory, options, callback = ->) ->
     process.chdir(packageDirectory)


### PR DESCRIPTION
Since Atom doesn't know the official name of packages when installing from Git URLs, we need a mechanism for passing that information from apm back to Atom so `settings-view` can activate the newly installed package.