### PR TITLE
fixes #531

### DIFF
--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -43,6 +43,7 @@ class Rebuild extends Command
       '--userconfig'
       config.getUserConfigPath()
       'rebuild'
+      "--runtime=electron"
       "--target=#{@electronVersion}"
       "--arch=#{config.getElectronArch()}"
     ]


### PR DESCRIPTION
Looking at https://github.com/mapbox/node-pre-gyp/pull/187/commits/ef79b3f52b08469105cd808af6d5a874c9ae5db2 (which doesn't work for apm) I got the feeling that just stating runtime=electron would be a pretty good idea. And it was.

Tried it by simply running:

> 
"/Applications/Atom Beta.app/Contents/Resources/app/apm/bin/node" "/Applications/Atom Beta.app/Contents/Resources/app/apm/node_modules/npm/bin/npm-cli.js" "--globalconfig" "/Users/viktor/.atom/.apm/.apmrc" "--userconfig" "/Users/viktor/.atom/.apmrc" "rebuild" "--target=0.34.5" "--arch=x64" "--runtime=electron"

Without --runtime=electron, node-pre-gyp fails like

* https://github.com/mapbox/node-pre-gyp/issues/188
* https://github.com/strongloop/fsevents/issues/93#issuecomment-146343196
* https://github.com/strongloop/fsevents/issues/93#issuecomment-156270459

