### PR TITLE
Do not throw errors if packages do not exist on apm uninstall --hard

### DIFF
--- a/src/uninstall.coffee
+++ b/src/uninstall.coffee
@@ -71,14 +71,14 @@ class Uninstall extends Command
             fs.removeSync(packageDirectory)
             if packageVersion
               uninstallsToRegister.push({packageName, packageVersion})
-          else
+          else if not options.argv.hard
             throw new Error("Does not exist")
 
         if options.argv.hard or options.argv.dev
           packageDirectory = path.join(devPackagesDirectory, packageName)
           if fs.existsSync(packageDirectory)
             fs.removeSync(packageDirectory)
-          else
+          else if not options.argv.hard
             throw new Error("Does not exist")
 
         @logSuccess()


### PR DESCRIPTION
I do not understand how it is an error unless both a dev package exists **and** a package exists.

Uninstall hard **should succeed** if the packages do not exist afterwards.