### PR TITLE
Make accidental unpublishes harder

### DIFF
--- a/spec/unpublish-spec.coffee
+++ b/spec/unpublish-spec.coffee
@@ -58,8 +58,8 @@ describe 'apm unpublish', ->
       describe 'when the user accepts the default answer', ->
         it 'does not unpublish the package', ->
           callback = jasmine.createSpy('callback')
-          spyOn(Unpublish.prototype, 'prompt').andCallFake (q, cb) -> cb('')
-          spyOn(Unpublish.prototype, 'unpublishPackage').andCallFake -> callback()
+          spyOn(Unpublish.prototype, 'prompt').andCallFake (args..., cb) -> cb('')
+          spyOn(Unpublish.prototype, 'unpublishPackage')
           apm.run(['unpublish', 'test-package'], callback)
 
           waitsFor 'waiting for unpublish command to complete', ->
@@ -107,8 +107,8 @@ describe 'apm unpublish', ->
       describe 'when the user accepts the default answer', ->
         it 'does not unpublish the package', ->
           callback = jasmine.createSpy('callback')
-          spyOn(Unpublish.prototype, 'prompt').andCallFake (q, cb) -> cb('')
-          spyOn(Unpublish.prototype, 'unpublishPackage').andCallFake -> callback()
+          spyOn(Unpublish.prototype, 'prompt').andCallFake (args..., cb) -> cb('')
+          spyOn(Unpublish.prototype, 'unpublishPackage')
           apm.run(['unpublish', 'test-package'], callback)
 
           waitsFor 'waiting for unpublish command to complete', ->

--- a/spec/unpublish-spec.coffee
+++ b/spec/unpublish-spec.coffee
@@ -55,6 +55,20 @@ describe 'apm unpublish', ->
         waitsFor 'waiting for prompt to be called', ->
           return Unpublish::prompt.argsForCall[0][0].match /unpublish ALL VERSIONS of 'test-package'.*irreversible/
 
+      describe 'when the user accepts the default answer', ->
+        it 'does not unpublish the package', ->
+          callback = jasmine.createSpy('callback')
+          spyOn(Unpublish.prototype, 'prompt').andCallFake (q, cb) -> cb('')
+          spyOn(Unpublish.prototype, 'unpublishPackage').andCallFake -> callback()
+          apm.run(['unpublish', 'test-package'], callback)
+
+          waitsFor 'waiting for unpublish command to complete', ->
+            callback.callCount > 0
+
+          runs ->
+            expect(Unpublish::unpublishPackage).not.toHaveBeenCalled()
+            expect(callback.argsForCall[0][0]).toMatch /Cancelled/
+
     describe "when the package does not exist", ->
       it "calls back with an error", ->
         callback = jasmine.createSpy('callback')
@@ -89,6 +103,20 @@ describe 'apm unpublish', ->
 
         waitsFor 'waiting for prompt to be called', ->
           return Unpublish::prompt.argsForCall[0][0].match /unpublish 'test-package@1.0.0'/
+
+      describe 'when the user accepts the default answer', ->
+        it 'does not unpublish the package', ->
+          callback = jasmine.createSpy('callback')
+          spyOn(Unpublish.prototype, 'prompt').andCallFake (q, cb) -> cb('')
+          spyOn(Unpublish.prototype, 'unpublishPackage').andCallFake -> callback()
+          apm.run(['unpublish', 'test-package'], callback)
+
+          waitsFor 'waiting for unpublish command to complete', ->
+            callback.callCount > 0
+
+          runs ->
+            expect(Unpublish::unpublishPackage).not.toHaveBeenCalled()
+            expect(callback.argsForCall[0][0]).toMatch /Cancelled/
 
     describe "when the version does not exist", ->
       it "calls back with an error", ->

--- a/spec/unpublish-spec.coffee
+++ b/spec/unpublish-spec.coffee
@@ -2,6 +2,7 @@ express = require 'express'
 http = require 'http'
 temp = require 'temp'
 apm = require '../lib/apm-cli'
+Unpublish = require '../lib/unpublish'
 
 describe 'apm unpublish', ->
   [server, unpublishPackageCallback, unpublishVersionCallback] = []
@@ -45,6 +46,15 @@ describe 'apm unpublish', ->
         expect(unpublishPackageCallback.callCount).toBe 1
         expect(unpublishVersionCallback.callCount).toBe 0
 
+    describe "when --force is not specified", ->
+      it 'prompts to unpublish ALL versions', ->
+        callback = jasmine.createSpy('callback')
+        spyOn(Unpublish.prototype, 'prompt')
+        apm.run(['unpublish', 'test-package'], callback)
+
+        waitsFor 'waiting for prompt to be called', ->
+          return Unpublish::prompt.argsForCall[0][0].match /unpublish ALL VERSIONS of 'test-package'.*irreversible/
+
     describe "when the package does not exist", ->
       it "calls back with an error", ->
         callback = jasmine.createSpy('callback')
@@ -70,6 +80,15 @@ describe 'apm unpublish', ->
         expect(callback.argsForCall[0][0]).toBeUndefined()
         expect(unpublishPackageCallback.callCount).toBe 0
         expect(unpublishVersionCallback.callCount).toBe 1
+
+    describe "when --force is not specified", ->
+      it 'prompts to unpublish that version', ->
+        callback = jasmine.createSpy('callback')
+        spyOn(Unpublish.prototype, 'prompt')
+        apm.run(['unpublish', 'test-package@1.0.0'], callback)
+
+        waitsFor 'waiting for prompt to be called', ->
+          return Unpublish::prompt.argsForCall[0][0].match /unpublish 'test-package@1.0.0'/
 
     describe "when the version does not exist", ->
       it "calls back with an error", ->

--- a/src/unpublish.coffee
+++ b/src/unpublish.coffee
@@ -61,16 +61,27 @@ class Unpublish extends Command
           callback()
 
   promptForConfirmation: (packageName, packageVersion, callback) ->
-    prompt = readline.createInterface(process.stdin, process.stdout)
-
     packageLabel = packageName
     packageLabel += "@#{packageVersion}" if packageVersion
 
-    prompt.question "Are you sure you want to unpublish #{packageLabel}? (yes) ", (answer) =>
-      prompt.close()
+    if packageVersion
+      question = "Are you sure you want to unpublish '#{packageLabel}'? (yes) "
+    else
+      question = "Are you sure you want to unpublish ALL VERSIONS of '#{packageLabel}'? " +
+                 "This will remove it from the apm registry, including " +
+                 "download counts and stars, and this action is irreversible. (yes)"
+
+    @prompt question, (answer) =>
       answer = if answer then answer.trim().toLowerCase() else 'yes'
       if answer in ['y', 'yes']
         @unpublishPackage(packageName, packageVersion, callback)
+
+  prompt: (question, callback) ->
+    prompt = readline.createInterface(process.stdin, process.stdout)
+
+    prompt.question question, (answer) ->
+      prompt.close()
+      callback(answer)
 
   run: (options) ->
     {callback} = options

--- a/src/unpublish.coffee
+++ b/src/unpublish.coffee
@@ -65,16 +65,18 @@ class Unpublish extends Command
     packageLabel += "@#{packageVersion}" if packageVersion
 
     if packageVersion
-      question = "Are you sure you want to unpublish '#{packageLabel}'? (yes) "
+      question = "Are you sure you want to unpublish '#{packageLabel}'? (no) "
     else
       question = "Are you sure you want to unpublish ALL VERSIONS of '#{packageLabel}'? " +
                  "This will remove it from the apm registry, including " +
-                 "download counts and stars, and this action is irreversible. (yes)"
+                 "download counts and stars, and this action is irreversible. (no)"
 
     @prompt question, (answer) =>
-      answer = if answer then answer.trim().toLowerCase() else 'yes'
+      answer = if answer then answer.trim().toLowerCase() else 'no'
       if answer in ['y', 'yes']
         @unpublishPackage(packageName, packageVersion, callback)
+      else
+        callback("Cancelled unpublishing #{packageLabel}")
 
   prompt: (question, callback) ->
     prompt = readline.createInterface(process.stdin, process.stdout)


### PR DESCRIPTION
Let's avoid another https://discuss.atom.io/t/apm-publish-help/28414

This PR includes two changes:

* If you `apm unpublish my-package` (without a version), apm attempts to make it *explicitly clear* what's about to happen.
* If you simply presses enter at the confirmation prompt, the default behavior is to cancel the unpublish; only "yes" or "y" will actually perform the destructive operation. Use `--force` if you *really know* you want to unpublish.

/cc @lee-dohm 