### PR TITLE
Fix truncated JSON output

### DIFF
--- a/src/featured.coffee
+++ b/src/featured.coffee
@@ -62,7 +62,7 @@ class Featured extends Command
       return callback(error) if error?
 
       if options.argv.json
-        console.log(JSON.stringify(packages))
+        process.stdout.write JSON.stringify(packages) + '\n', callback
       else
         if options.argv.themes
           console.log "#{'Featured Atom Themes'.cyan} (#{packages.length})"
@@ -79,7 +79,7 @@ class Featured extends Command
         console.log "Use `apm install` to install them or visit #{'http://atom.io/packages'.underline} to read more about them."
         console.log()
 
-      callback()
+        callback()
 
     if options.argv.themes
       @getFeaturedPackagesByType(options.argv.compatible, 'themes', listCallback)

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -658,5 +658,7 @@ class Install extends Command
       installedPackagesInfo = _.compact(installedPackagesInfo)
       installedPackagesInfo = installedPackagesInfo.filter (item, idx) ->
         packageNames[idx] isnt "."
-      console.log(JSON.stringify(installedPackagesInfo, null, "  ")) if options.argv.json
-      callback(null)
+      if options.argv.json
+        process.stdout.write JSON.stringify(installedPackagesInfo, null, "  ") + '\n', callback
+      else
+        callback(null)

--- a/src/list.coffee
+++ b/src/list.coffee
@@ -166,8 +166,7 @@ class List extends Command
           @listGitPackages options, (error, packages) ->
             return callback(error) if error
             output.git = packages
-            console.log JSON.stringify(output)
-            callback()
+            process.stdout.write JSON.stringify(output) + '\n', callback
 
   run: (options) ->
     {callback} = options

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -69,7 +69,7 @@ class Search extends Command
         return
 
       if options.argv.json
-        console.log(JSON.stringify(packages))
+        process.stdout.write JSON.stringify(packages) + '\n', callback
       else
         heading = "Search Results For '#{query}'".cyan
         console.log "#{heading} (#{packages.length})"
@@ -84,4 +84,4 @@ class Search extends Command
         console.log "Use `apm install` to install them or visit #{'http://atom.io/packages'.underline} to read more about them."
         console.log()
 
-      callback()
+        callback()

--- a/src/stars.coffee
+++ b/src/stars.coffee
@@ -64,8 +64,7 @@ class Stars extends Command
     new Install().run({commandArgs, callback})
 
   logPackagesAsJson: (packages, callback) ->
-    console.log(JSON.stringify(packages))
-    callback()
+    process.stdout.write JSON.stringify(packages) + '\n', callback
 
   logPackagesAsText: (user, packagesAreThemes, packages, callback) ->
     userLabel = user ? 'you'


### PR DESCRIPTION
This fixes a bug occurring with recent Node.js versions, where the output of `apm list --json` is truncated after 65536 characters.
In new Node.js (version 5 or 6), [console.log becomes asynchronous](https://nodejs.org/api/console.html#console_asynchronous_vs_synchronous_consoles), so with big outputs, like the above example, [the callback](https://github.com/atom/apm/blob/master/src/list.coffee#L170) that exits the process runs before the output completes.

I tested this patch in the [apm that I package for Arch Linux](https://github.com/tensor5/arch-atom), where I use the system installed Node rather than the one that ships with apm, and it seems to work fine.