### PR TITLE
Fix publish test

### DIFF
--- a/spec/publish-spec.coffee
+++ b/spec/publish-spec.coffee
@@ -35,7 +35,7 @@ describe 'apm publish', ->
       callback.callCount is 1
 
     runs ->
-      expect(callback.mostRecentCall.args[0].message).toBe 'Error parsing package.json file: Unexpected token }'
+      expect(callback.mostRecentCall.args[0].message).toContain 'Error parsing package.json file: Unexpected token }'
 
   it "validates the package is in a Git repository", ->
     packageToPublish = temp.mkdirSync('apm-test-package-')


### PR DESCRIPTION
This PR fixes the test in `publish-spec.coffee` which fails on OSX (10.11.5) due to expecting the wrong error output.