### PR TITLE
Fix output truncation when exiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "asar-require": "0.2.0",
     "async": "~0.2.8",
     "colors": "~0.6.1",
-    "exit": "0.1.2",
     "first-mate": "^5.0",
     "fs-plus": "2.x",
     "git-utils": "^4.0",

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -1,10 +1,6 @@
 apm = require './apm-cli'
 
 process.title = 'apm'
+
 apm.run process.argv.slice(2), (error) ->
-  code = if error? then 1 else 0
-  if process.platform is 'win32'
-    exit = require('exit')
-    exit(code)
-  else
-    process.exit(code)
+  process.exitCode = if error? then 1 else 0


### PR DESCRIPTION
Calling `process.exit()` keeps the stdout and stderr from fully flushing. The `exit` module handles this, but in more recent Nodes, we can simply set `process.exitCode` and let Node exit when it's done with the event loop.