### PR TITLE
Download the correct Node binary for ARM machines

### DIFF
--- a/script/download-node.js
+++ b/script/download-node.js
@@ -12,6 +12,14 @@ var getInstallNodeVersion = require('./bundled-node-version')
 
 temp.track();
 
+var identifyArch = function() {
+  var arch = process.arch === 'ia32' ? 'x86' : process.arch;
+  if (arch == 'arm') {
+    arch = "armv" + process.config.variables.arm_version + "l";
+  }
+  return arch;
+}
+
 var downloadFileToLocation = function(url, filename, callback) {
   var stream = fs.createWriteStream(filename);
   stream.on('end', callback);
@@ -39,7 +47,7 @@ var downloadTarballAndExtract = function(url, location, callback) {
 };
 
 var copyNodeBinToLocation = function(callback, version, targetFilename, fromDirectory) {
-  var arch = process.arch === 'ia32' ? 'x86' : process.arch;
+  var arch = identifyArch();
   var subDir = "node-" + version + "-" + process.platform + "-" + arch;
   var downloadedNodePath = path.join(fromDirectory, subDir, 'bin', 'node');
   return mv(downloadedNodePath, targetFilename, {mkdirp: true}, function(err) {
@@ -63,10 +71,7 @@ var downloadNode = function(version, done) {
     downloadURL = "http://nodejs.org/dist/" + version + "/win-" + arch + "node.exe";
     filename = path.join('bin', "node.exe");
   } else {
-    arch = process.arch === 'ia32' ? 'x86' : process.arch;
-    if (arch == 'arm') {
-      arch = "armv" + process.config.variables.arm_version + "l";
-    }
+    arch = identifyArch();
     downloadURL = "http://nodejs.org/dist/" + version + "/node-" + version + "-" + process.platform + "-" + arch + ".tar.gz";
     filename = path.join('bin', "node");
   }

--- a/script/download-node.js
+++ b/script/download-node.js
@@ -64,6 +64,9 @@ var downloadNode = function(version, done) {
     filename = path.join('bin', "node.exe");
   } else {
     arch = process.arch === 'ia32' ? 'x86' : process.arch;
+    if (arch == 'arm') {
+      arch = "armv" + process.config.variables.arm_version + "l";
+    }
     downloadURL = "http://nodejs.org/dist/" + version + "/node-" + version + "-" + process.platform + "-" + arch + ".tar.gz";
     filename = path.join('bin', "node");
   }


### PR DESCRIPTION
This should fix https://github.com/atom/apm/issues/568.

I noticed for the first time an error message that said:

```
download not found: http://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-arm.tar.gz
```

I checked [the Node distribution page](https://nodejs.org/en/download/current/) and found that the URL for ARM machines includes the ARM CPU version.