### PR TITLE
Fix node-gyp path

### DIFF
--- a/bin/apm.cmd
+++ b/bin/apm.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-set maybe_node_gyp_path=%~dp0\..\node_modules\.bin\node-gyp
+set maybe_node_gyp_path=%~dp0\..\node_modules\node-gyp\bin\node-gyp.js
 if exist %maybe_node_gyp_path% (
   set npm_config_node_gyp=%maybe_node_gyp_path%
 )

--- a/bin/apm.cmd
+++ b/bin/apm.cmd
@@ -1,10 +1,13 @@
+@echo off
+setlocal
+
 set maybe_node_gyp_path=%~dp0\..\node_modules\.bin\node-gyp
 if exist %maybe_node_gyp_path% (
   set npm_config_node_gyp=%maybe_node_gyp_path%
 )
 
-@IF EXIST "%~dp0\node.exe" (
+if exist "%~dp0\node.exe" (
   "%~dp0\node.exe" "%~dp0/../lib/cli.js" %*
-) ELSE (
+) else (
   node.exe "%~dp0/../lib/cli.js" %*
 )


### PR DESCRIPTION
This PR currently only handles `apm.cmd`.  I'd like to get some feedback before applying the change to the other files as well.

`npm_config_node_gyp` requires a `node-gyp.js` file rather than a bash/batch script, so supply it one.  This fixes Node trying to parse the `node-gyp` bash file as JS instead.

I've also turned off echo so that the `set` and `if` commands don't output to console.

I'm not sure if `npm.cmd` needs to set `npm_config_node_gyp` in the first place, as I didn't get any errors through that, only through `apm.cmd`.

Refs atom/atom#11897.

/cc @ben3eeE, @BinaryMuse 