### PR TITLE
Upgrade deprecated packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,12 +50,14 @@
   },
   "devDependencies": {
     "jasmine-focused": ">=1.0.7 <2.0",
-    "grunt": "~0.4.1",
-    "grunt-contrib-coffee": "~0.12.0",
+    "grunt": "^1.0.1",
+    "grunt-coffeelint": "0.0.16",
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-coffee": "^1.0.0",
     "grunt-cli": "~0.1.8",
-    "grunt-shell": "~0.2.2",
+    "grunt-shell": "^1.3.0",
     "express": "~3.2.3",
-    "grunt-coffeelint": "0.0.15",
+    "grunt-coffeelint": "0.0.16",
     "coffee-script": "^1.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,15 +49,13 @@
     "yargs": "^3.23.0"
   },
   "devDependencies": {
-    "jasmine-focused": ">=1.0.7 <2.0",
+    "coffee-script": "^1.8.0",
+    "express": "~3.2.3",
     "grunt": "^1.0.1",
     "grunt-coffeelint": "0.0.16",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-coffee": "^1.0.0",
-    "grunt-cli": "~0.1.8",
     "grunt-shell": "^1.3.0",
-    "express": "~3.2.3",
-    "grunt-coffeelint": "0.0.16",
-    "coffee-script": "^1.8.0"
+    "jasmine-focused": ">=1.0.7 <2.0"
   }
 }


### PR DESCRIPTION
The primary goal of this PR was to silence the graceful-fs spam when building Atom, etc. Turns out there are other deprecations as well that should be resolved. In particular the fact that [wrench](https://www.npmjs.com/package/wrench) has been deprecated with a recommendation to replace it with [fs-extra](https://www.npmjs.com/package/fs-extra).

- [x] Upgrade grunt + friends to resolve graceful-fs warning.
- ~~Replace wrench with fs-extra (or something else).~~ Expands the scope of this PR too much. Better to do that work in a separate PR.
