### PR TITLE
Fix Windows build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,15 +2,16 @@ version: "{build}"
 
 os: Windows Server 2012 R2
 
+environment:
+  nodejs_version: "4.4.5"
+
 install:
-  - choco install atom -y
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - ".\\bin\\npm clean"
-  - ".\\bin\\npm install"
+  - npm install -g npm
+  - npm clean
+  - npm install
 
 build_script:
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - ".\\bin\\npm test"
+  - npm test
 
 test: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,13 @@ version: "{build}"
 
 os: Windows Server 2012 R2
 
+platform: x86
+
 environment:
   nodejs_version: "4.4.5"
 
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:nodejs_version $env:platform
   - npm install -g npm
   - npm install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
   nodejs_version: "4.4.5"
 
 install:
+  - ps: Install-Product node $env:nodejs_version
   - npm install -g npm
   - npm install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,6 @@ install:
   - npm install -g npm
   - npm install
 
-build_script:
-  - npm test
-
 test: off
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ install:
   - npm install -g npm
   - npm install
 
+build: off
+
 test: off
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ environment:
 
 install:
   - npm install -g npm
-  - npm clean
   - npm install
 
 build_script:

--- a/bin/npm
+++ b/bin/npm
@@ -1,9 +1,11 @@
 #!/bin/bash
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export PATH="$SCRIPT_DIR:$PATH"
+
 maybe_node_gyp_path="$SCRIPT_DIR"/../node_modules/.bin/node-gyp
 if [ -e "$maybe_node_gyp_path" ]
 then
   export npm_config_node_gyp="$maybe_node_gyp_path"
 fi
-export PATH="$SCRIPT_DIR:$PATH"
+
 "$SCRIPT_DIR"/../node_modules/.bin/npm $@

--- a/bin/npm.cmd
+++ b/bin/npm.cmd
@@ -1,17 +1,6 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-:: Try to find git.exe in path
-for /f "tokens=*" %%G in ('where git') do set "apm_git_path=%%~dpG"
-if not defined apm_git_path (
-  :: Try to find git.exe in GitHub Desktop, oldest first so we end with newest
-  for /f "tokens=*" %%d in ('dir /b /s /a:d /od "%LOCALAPPDATA%\GitHub\PortableGit*"') do (
-    if exist %%d\cmd\git.exe set apm_git_path=%%d\cmd
-  )
-  :: Found one, add it to the path
-  if defined apm_git_path set "Path=!apm_git_path!;%PATH%"
-)
-
 set "PATH=%~dp0;%PATH%"
 set maybe_node_gyp_path=%~dp0\..\node_modules\node-gyp\bin\node-gyp.js
 if exist %maybe_node_gyp_path% (

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom-package-manager",
   "description": "Atom package manager",
-  "version": "1.11.4",
+  "version": "1.12.0-beta0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/script/bundled-node-version.js
+++ b/script/bundled-node-version.js
@@ -1,4 +1,6 @@
 module.exports = function(filename, callback) {
+  console.log('Executing bundled-node-version.js')
+  console.trace()
   require('child_process').exec(filename + ' -v', function(error, stdout) {
     var version = null;
     if (stdout != null) {

--- a/script/bundled-node-version.js
+++ b/script/bundled-node-version.js
@@ -1,6 +1,4 @@
 module.exports = function(filename, callback) {
-  console.log('Executing bundled-node-version.js')
-  console.trace()
   require('child_process').exec(filename + ' -v', function(error, stdout) {
     var version = null;
     if (stdout != null) {

--- a/script/download-node.js
+++ b/script/download-node.js
@@ -23,7 +23,13 @@ var downloadFileToLocation = function(url, filename, callback) {
   var stream = fs.createWriteStream(filename);
   stream.on('end', callback);
   stream.on('error', callback);
-  request.get(url).pipe(stream);
+  requestStream.on('response', function(response) {
+    if (response.statusCode == 404) {
+      console.error('download not found:', url);
+      process.exit(1);
+    }
+    requestStream.pipe(stream);
+  });
 };
 
 var downloadTarballAndExtract = function(url, location, callback) {

--- a/script/download-node.js
+++ b/script/download-node.js
@@ -23,6 +23,7 @@ var downloadFileToLocation = function(url, filename, callback) {
   var stream = fs.createWriteStream(filename);
   stream.on('end', callback);
   stream.on('error', callback);
+  var requestStream = request.get(url)
   requestStream.on('response', function(response) {
     if (response.statusCode == 404) {
       console.error('download not found:', url);

--- a/script/download-node.js
+++ b/script/download-node.js
@@ -7,7 +7,6 @@ var tar = require('tar');
 var temp = require('temp');
 
 var request = require('request');
-
 var getInstallNodeVersion = require('./bundled-node-version')
 
 temp.track();
@@ -67,13 +66,13 @@ var downloadNode = function(version, done) {
     if (process.env.JANKY_SHA1)
       arch = ''; // Always download 32-bit node on Atom Windows CI builds
     else
-      arch = process.arch === 'x64' ? 'x64/' : '';
+      arch = process.arch === 'x64' ? 'x64/' : 'x86/';
     downloadURL = "http://nodejs.org/dist/" + version + "/win-" + arch + "node.exe";
-    filename = path.join('bin', "node.exe");
+    filename = path.join(__dirname, '..', 'bin', "node.exe");
   } else {
     arch = identifyArch();
     downloadURL = "http://nodejs.org/dist/" + version + "/node-" + version + "-" + process.platform + "-" + arch + ".tar.gz";
-    filename = path.join('bin', "node");
+    filename = path.join(__dirname, '..', 'bin', "node");
   }
 
   var downloadFile = function() {

--- a/script/postinstall.cmd
+++ b/script/postinstall.cmd
@@ -3,7 +3,11 @@ setlocal EnableDelayedExpansion
 setlocal EnableExtensions
 
 echo ^>^> Downloading bundled Node
-node script/download-node.js
+node .\script\download-node.js
+echo ^>^> Downloaded Node version
+
+echo The version of Node we downloaded:
+call .\bin\node.exe -v
 
 echo ""
 for /f "delims=" %%i in ('.\bin\node.exe -v') do set bundledVersion=%%i

--- a/script/postinstall.cmd
+++ b/script/postinstall.cmd
@@ -4,7 +4,6 @@ setlocal EnableExtensions
 
 echo ^>^> Downloading bundled Node
 node .\script\download-node.js
-echo ^>^> Downloaded Node version
 
 echo The version of Node we downloaded:
 call .\bin\node.exe -v


### PR DESCRIPTION
This should unblock using AppVeyor on atom/atom#12170.

The main issue with the previous scripts was that we were building the URL for downloading Node x86 for Windows in a wrong way, which was preventing it from being downloaded. As part of fixing that, we have also restructured the scripts a little bit to make them more similar to their Mac/Linux counterparts.

Please, note that we have disabled running tests because some of them appear to be written in a platform-specific way. I think fixing them can be deferred to another pull-request, so that we can start using the new version of apm on Atom right away. /cc: @damieng 

/cc: @nathansobo @atom/core 