### PR TITLE
Disable progress when running npm

### DIFF
--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -112,5 +112,5 @@ module.exports =
         ;
         ; You should instead edit your .apmrc config located in ~/.atom/.apmrc
         cache = #{@getCacheDirectory()}
-
+        progress = false
       """

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -112,5 +112,6 @@ module.exports =
         ;
         ; You should instead edit your .apmrc config located in ~/.atom/.apmrc
         cache = #{@getCacheDirectory()}
+        ; Hide progress-bar to prevent npm from altering apm console output.
         progress = false
       """


### PR DESCRIPTION
This regressed in #562, causing every `apm` command that delegates to `npm` to show something like the following:

![progress-before](https://cloud.githubusercontent.com/assets/482957/17020571/a5155706-4f42-11e6-81c6-8c251954c743.gif)

With this pull-request we disable progress report by default in `~/.atom/.apm/.apmrc`, so that running `npm` commands doesn't show the native progress-bar.

![progress-after](https://cloud.githubusercontent.com/assets/482957/17020597/c5763132-4f42-11e6-975c-d8fb29e90e67.gif)

/cc: @BinaryMuse @kuychaco @nathansobo @atom/core 