### PR TITLE
Fix missing and hardcoded flags

### DIFF
--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -36,7 +36,7 @@ class Dedupe extends Command
     installNodeArgs.push("--runtime=electron")
     installNodeArgs.push("--target=#{@electronVersion}")
     installNodeArgs.push("--dist-url=#{config.getElectronUrl()}")
-    installNodeArgs.push('--arch=ia32')
+    installNodeArgs.push("--arch=#{config.getElectronArch()}")
     installNodeArgs.push('--ensure')
 
     env = _.extend({}, process.env, HOME: @atomNodeDirectory)
@@ -74,7 +74,7 @@ class Dedupe extends Command
     dedupeArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'dedupe']
     dedupeArgs.push("--runtime=electron")
     dedupeArgs.push("--target=#{@electronVersion}")
-    dedupeArgs.push('--arch=ia32')
+    dedupeArgs.push("--arch=#{config.getElectronArch()}")
     dedupeArgs.push('--silent') if options.argv.silent
     dedupeArgs.push('--quiet') if options.argv.quiet
 

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -33,6 +33,7 @@ class Dedupe extends Command
 
   installNode: (callback) ->
     installNodeArgs = ['install']
+    installNodeArgs.push("--runtime=electron")
     installNodeArgs.push("--target=#{@electronVersion}")
     installNodeArgs.push("--dist-url=#{config.getElectronUrl()}")
     installNodeArgs.push('--arch=ia32')
@@ -71,6 +72,7 @@ class Dedupe extends Command
 
   forkDedupeCommand: (options, callback) ->
     dedupeArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'dedupe']
+    dedupeArgs.push("--runtime=electron")
     dedupeArgs.push("--target=#{@electronVersion}")
     dedupeArgs.push('--arch=ia32')
     dedupeArgs.push('--silent') if options.argv.silent

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -95,6 +95,7 @@ class Install extends Command
 
     installArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'install']
     installArgs.push(modulePath)
+    installArgs.push("--runtime=electron")
     installArgs.push("--target=#{@electronVersion}")
     installArgs.push("--arch=#{config.getElectronArch()}")
     installArgs.push("--global-style") if installGlobally
@@ -189,6 +190,7 @@ class Install extends Command
 
   forkInstallCommand: (options, callback) ->
     installArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'install']
+    installArgs.push("--runtime=electron")
     installArgs.push("--target=#{@electronVersion}")
     installArgs.push("--arch=#{config.getElectronArch()}")
     installArgs.push('--silent') if options.argv.silent
@@ -418,6 +420,7 @@ class Install extends Command
 
       buildArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'build']
       buildArgs.push(path.resolve(__dirname, '..', 'native-module'))
+      buildArgs.push("--runtime=electron")
       buildArgs.push("--target=#{@electronVersion}")
       buildArgs.push("--arch=#{config.getElectronArch()}")
 

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -60,6 +60,7 @@ class Install extends Command
 
   installNode: (callback) =>
     installNodeArgs = ['install']
+    installNodeArgs.push("--runtime=electron")
     installNodeArgs.push("--target=#{@electronVersion}")
     installNodeArgs.push("--dist-url=#{config.getElectronUrl()}")
     installNodeArgs.push("--arch=#{config.getElectronArch()}")

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -43,6 +43,7 @@ class Rebuild extends Command
       '--userconfig'
       config.getUserConfigPath()
       'rebuild'
+      '--runtime=electron'
       "--target=#{@electronVersion}"
       "--arch=#{config.getElectronArch()}"
     ]


### PR DESCRIPTION
This pull-request fixes a problem when installing dependencies via `apm` that prevents the runtime from being recognized, causing packages such as nodegit to fail the build. In particular, we are adding the `--runtime=electron` flag to every `npm` command that interfaces with modules installation and their subsequent compilation. 

Please, note that this is the approach that [electron-rebuild uses too](https://github.com/electron/electron-rebuild/blob/27158b165715731836425369c5c5e680420c7cd9/src/main.js#L122-L126).

While in the process of adding such flag, we spotted a couple of places in the `dedupe` command where the target architecture of native modules was being hardcoded; this was probably not an issue, but it feels reasonable to use `config.getElectronArch()` as we do elsewhere.

@atom/core: I'd ❤️ to have some more 👀 on this, so that we can 🚢 it before getting the new `apm` version into beta.