### PR TITLE
Stop using shadow DOM selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "asar-require": "0.3.0",
     "async": "~0.2.8",
     "colors": "~0.6.1",
-    "first-mate": "^5.0",
+    "first-mate": "6.2.0",
     "fs-plus": "2.x",
     "git-utils": "^4.0",
     "hosted-git-info": "^2.1.4",

--- a/spec/init-spec.coffee
+++ b/spec/init-spec.coffee
@@ -157,12 +157,12 @@ describe "apm init", ->
           expect(fs.readFileSync(path.join(themePath, 'styles', 'base.less'), 'utf8')).toContain """
             @import "syntax-variables";
 
-            atom-text-editor, :host {
+            atom-text-editor {
               background-color: @syntax-background-color;
               color: @syntax-text-color;
             }
 
-            atom-text-editor .gutter, :host .gutter {
+            atom-text-editor .gutter {
               background-color: @syntax-gutter-background-color;
               color: @syntax-gutter-text-color;
             }

--- a/src/text-mate-theme.coffee
+++ b/src/text-mate-theme.coffee
@@ -137,7 +137,7 @@ class TextMateTheme
         properties: @translateScopeSelectorSettings(settings)
 
   translateScopeSelector: (textmateScopeSelector) ->
-    new ScopeSelector(textmateScopeSelector).toCssSelector()
+    new ScopeSelector(textmateScopeSelector).toCssSyntaxSelector()
 
   translateScopeSelectorSettings: ({foreground, background, fontStyle}) ->
     properties = {}

--- a/src/text-mate-theme.coffee
+++ b/src/text-mate-theme.coffee
@@ -64,75 +64,67 @@ class TextMateTheme
 
   buildGlobalSettingsRulesets: (settings) ->
     @rulesets.push
-      selector: 'atom-text-editor, :host'
+      selector: 'atom-text-editor'
       properties:
         'background-color': '@syntax-background-color'
         'color': '@syntax-text-color'
 
     @rulesets.push
-      selector: 'atom-text-editor .gutter, :host .gutter'
+      selector: 'atom-text-editor .gutter'
       properties:
         'background-color': '@syntax-gutter-background-color'
         'color': '@syntax-gutter-text-color'
 
     @rulesets.push
-      selector: 'atom-text-editor .gutter .line-number.cursor-line,
-                 :host .gutter .line-number.cursor-line'
+      selector: 'atom-text-editor .gutter .line-number.cursor-line'
       properties:
         'background-color': '@syntax-gutter-background-color-selected'
         'color': '@syntax-gutter-text-color-selected'
 
     @rulesets.push
-      selector: 'atom-text-editor .gutter .line-number.cursor-line-no-selection,
-                 :host .gutter .line-number.cursor-line-no-selection'
+      selector: 'atom-text-editor .gutter .line-number.cursor-line-no-selection'
       properties:
         'color': '@syntax-gutter-text-color-selected'
 
     @rulesets.push
-      selector: 'atom-text-editor .wrap-guide, :host .wrap-guide'
+      selector: 'atom-text-editor .wrap-guide'
       properties:
         'color': '@syntax-wrap-guide-color'
 
     @rulesets.push
-      selector: 'atom-text-editor .indent-guide, :host .indent-guide'
+      selector: 'atom-text-editor .indent-guide'
       properties:
         'color': '@syntax-indent-guide-color'
 
     @rulesets.push
-      selector: 'atom-text-editor .invisible-character, :host .invisible-character'
+      selector: 'atom-text-editor .invisible-character'
       properties:
         'color': '@syntax-invisible-character-color'
 
     @rulesets.push
-      selector: 'atom-text-editor .search-results .marker .region,
-                 :host .search-results .marker .region'
+      selector: 'atom-text-editor .search-results .marker .region'
       properties:
         'background-color': 'transparent'
         'border': '@syntax-result-marker-color'
 
     @rulesets.push
-      selector: 'atom-text-editor .search-results .marker.current-result .region,
-                 :host .search-results .marker.current-result .region'
+      selector: 'atom-text-editor .search-results .marker.current-result .region'
       properties:
         'border': '@syntax-result-marker-color-selected'
 
     @rulesets.push
-      selector: 'atom-text-editor.is-focused .cursor,
-                 :host(.is-focused) .cursor'
+      selector: 'atom-text-editor.is-focused .cursor'
       properties:
         'border-color': '@syntax-cursor-color'
 
     @rulesets.push
-      selector: 'atom-text-editor.is-focused .selection .region,
-                 :host(.is-focused) .selection .region'
+      selector: 'atom-text-editor.is-focused .selection .region'
       properties:
         'background-color': '@syntax-selection-color'
 
     @rulesets.push
       selector: 'atom-text-editor.is-focused .line-number.cursor-line-no-selection,
-                 atom-text-editor.is-focused .line.cursor-line,
-                 :host(.is-focused) .line-number.cursor-line-no-selection,
-                 :host(.is-focused) .line.cursor-line'
+                 atom-text-editor.is-focused .line.cursor-line'
       properties:
         'background-color': @translateColor(settings.lineHighlight)
 

--- a/templates/theme/styles/base.less
+++ b/templates/theme/styles/base.less
@@ -1,6 +1,6 @@
 @import "syntax-variables";
 
-atom-text-editor, :host {
+atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
@@ -51,257 +51,260 @@ atom-text-editor, :host {
   }
 }
 
-atom-text-editor .search-results .marker .region,
-:host .search-results .marker .region {
+atom-text-editor .search-results .marker .region {
   background-color: transparent;
   border: 1px solid @syntax-result-marker-color;
 }
 
-atom-text-editor .search-results .marker.current-result .region,
-:host .search-results .marker.current-result .region {
+atom-text-editor .search-results .marker.current-result .region {
   border: 1px solid @syntax-result-marker-color-selected;
 }
 
-.comment {
+
+// Syntax styles
+
+.syntax--comment {
   color: @light-gray;
 }
 
-.keyword {
+.syntax--keyword {
   color: @purple;
 
-  &.control {
+  &.syntax--control {
     color: @purple;
   }
 
-  &.operator {
+  &.syntax--operator {
     color: @syntax-text-color;
   }
 
-  &.other.special-method {
+  &.syntax--other.syntax--special-method {
     color: @blue;
   }
 
-  &.other.unit {
+  &.syntax--other.syntax--unit {
     color: @orange;
   }
 }
 
-.storage {
+.syntax--storage {
   color: @purple;
 }
 
-.constant {
+.syntax--constant {
   color: @orange;
 
-  &.character.escape {
+  &.syntax--character.syntax--escape {
     color: @cyan;
   }
 
-  &.numeric {
+  &.syntax--numeric {
     color: @orange;
   }
 
-  &.other.color {
+  &.syntax--other.syntax--color {
     color: @cyan;
   }
 
-  &.other.symbol {
+  &.syntax--other.syntax--symbol {
     color: @green;
   }
 }
 
-.variable {
+.syntax--variable {
   color: @red;
 
-  &.interpolation {
+  &.syntax--interpolation {
     color: darken(@red, 10%);
   }
 
-  &.parameter.function {
+  &.syntax--parameter.syntax--function {
     color: @syntax-text-color;
   }
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
   background-color: @red;
   color: @syntax-background-color;
 }
 
-.string {
+.syntax--string {
   color: @green;
 
 
-  &.regexp {
+  &.syntax--regexp {
     color: @cyan;
 
-    .source.ruby.embedded {
+    .syntax--source.syntax--ruby.syntax--embedded {
       color: @orange;
     }
   }
 
-  &.other.link {
+  &.syntax--other.syntax--link {
     color: @red;
   }
 }
 
-.punctuation {
-  &.definition {
-    &.comment {
+.syntax--punctuation {
+  &.syntax--definition {
+    &.syntax--comment {
       color: @light-gray;
     }
 
-    &.string,
-    &.variable,
-    &.parameters,
-    &.array {
+    &.syntax--string,
+    &.syntax--variable,
+    &.syntax--parameters,
+    &.syntax--array {
       color: @syntax-text-color;
     }
 
-    &.heading,
-    &.identity {
+    &.syntax--heading,
+    &.syntax--identity {
       color: @blue;
     }
 
-    &.bold {
+    &.syntax--bold {
       color: @light-orange;
       font-weight: bold;
     }
 
-    &.italic {
+    &.syntax--italic {
       color: @purple;
       font-style: italic;
     }
   }
 
-  &.section.embedded {
+  &.syntax--section.syntax--embedded {
     color: darken(@red, 10%);
   }
 
 }
 
-.support {
-  &.class {
+.syntax--support {
+  &.syntax--class {
     color: @light-orange;
   }
 
-  &.function  {
+  &.syntax--function  {
     color: @cyan;
 
-    &.any-method {
+    &.syntax--any-method {
       color: @blue;
     }
   }
 }
 
-.entity {
-  &.name.function {
+.syntax--entity {
+  &.syntax--name.syntax--function {
     color: @blue;
   }
-  &.name.type {
+  &.syntax--name.syntax--type {
     color: @light-orange;
     text-decoration: underline;
   }
 
-  &.other.inherited-class {
+  &.syntax--other.syntax--inherited-class {
     color: @green;
   }
-  &.name.class, &.name.type.class {
+  &.syntax--name.syntax--class, &.syntax--name.syntax--type.syntax--class {
     color: @light-orange;
   }
 
-  &.name.section {
+  &.syntax--name.syntax--section {
     color: @blue;
   }
 
-  &.name.tag {
+  &.syntax--name.syntax--tag {
     color: @red;
     text-decoration: underline;
   }
 
-  &.other.attribute-name {
+  &.syntax--other.syntax--attribute-name {
     color: @orange;
 
-    &.id {
+    &.syntax--id {
       color: @blue;
     }
   }
 }
 
-.meta {
-  &.class {
+.syntax--meta {
+  &.syntax--class {
     color: @light-orange;
   }
 
-  &.link {
+  &.syntax--link {
     color: @orange;
   }
 
-  &.require {
+  &.syntax--require {
     color: @blue;
   }
 
-  &.selector {
+  &.syntax--selector {
     color: @purple;
   }
 
-  &.separator {
+  &.syntax--separator {
     background-color: @gray;
     color: @syntax-text-color;
   }
 }
 
-.none {
+.syntax--none {
   color: @syntax-text-color;
 }
 
-.markup {
-  &.bold {
+.syntax--markup {
+  &.syntax--bold {
     color: @orange;
     font-weight: bold;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @purple;
   }
 
-  &.deleted {
+  &.syntax--deleted {
     color: @red;
   }
 
-  &.italic {
+  &.syntax--italic {
     color: @purple;
     font-style: italic;
   }
 
-  &.heading .punctuation.definition.heading {
+  &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
     color: @blue;
   }
 
-  &.inserted {
+  &.syntax--inserted {
     color: @green;
   }
 
-  &.list {
+  &.syntax--list {
     color: @red;
   }
 
-  &.quote {
+  &.syntax--quote {
     color: @orange;
   }
 
-  &.raw.inline {
+  &.syntax--raw.syntax--inline {
     color: @green;
   }
 }
 
-.source.gfm .markup {
+.syntax--source.syntax--gfm .syntax--markup {
   -webkit-font-smoothing: auto;
-  &.heading {
+  &.syntax--heading {
     color: @green;
   }
 }
 
-atom-text-editor[mini] .scroll-view,
-:host([mini]) .scroll-view {
+
+// Mini editor
+
+atom-text-editor[mini] .scroll-view {
   padding-left: 1px;
 }


### PR DESCRIPTION
We are in the process of removing the shadow DOM boundary from `atom-text-editor` elements. This pull request upgrades existing selectors so that they:

* Stop using `:host`.
* Stop using `atom-text-editor::shadow`.
* Prepend syntax class names with `syntax--`.

## TODO

- [x] Theme generator (`templates/theme`)
- [x] Remove `:host` from TextMate converter (`src/text-mate-theme.coffee`)
- [x] :arrow_up: first-mate to prepend selectors with `syntax--` when converting TextMate themes (https://github.com/atom/first-mate/pull/80)