### PR TITLE
fix apm list to show packages as disabled again

### DIFF
--- a/spec/list-spec.coffee
+++ b/spec/list-spec.coffee
@@ -3,6 +3,7 @@ fs = require 'fs-plus'
 temp = require 'temp'
 wrench = require 'wrench'
 apm = require '../lib/apm-cli'
+CSON = require 'season'
 
 listPackages = (args, doneCallback) ->
   callback = jasmine.createSpy('callback')
@@ -78,7 +79,8 @@ describe 'apm list', ->
     fs.makeTreeSync(packagesPath)
     wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'test-module'), path.join(packagesPath, 'test-module'))
     configPath = path.join(atomHome, 'config.cson')
-    fs.writeFileSync(configPath, 'core: disabledPackages: ["test-module"]')
+    CSON.writeFileSync configPath, '*':
+      core: disabledPackages: ["test-module"]
 
     listPackages [], ->
       expect(console.log.argsForCall[1][0]).toContain 'test-module@1.0.0 (disabled)'

--- a/src/list.coffee
+++ b/src/list.coffee
@@ -19,7 +19,7 @@ class List extends Command
     @devPackagesDirectory = path.join(config.getAtomDirectory(), 'dev', 'packages')
     if configPath = CSON.resolve(path.join(config.getAtomDirectory(), 'config'))
       try
-        @disabledPackages = CSON.readFileSync(configPath)?.core?.disabledPackages
+        @disabledPackages = CSON.readFileSync(configPath)?['*']?.core?.disabledPackages
     @disabledPackages ?= []
 
   parseOptions: (argv) ->


### PR DESCRIPTION
apm doesn't show `(disabled)` anymore after disabled packages.  This PR fixes that.

It looks like this functionality has been broken for a while.

Found by @michaelsanford in https://github.com/atom/apm/issues/616
