### PR TITLE
ensure (empty) isn't printed when no git packages

### DIFF
--- a/src/list.coffee
+++ b/src/list.coffee
@@ -53,7 +53,7 @@ class List extends Command
         packageLine = pack.name
         packageLine += "@#{pack.version}" if pack.version?
         console.log packageLine
-    else
+    else if packages.length > 0
       tree packages, (pack) =>
         packageLine = pack.name
         packageLine += "@#{pack.version}" if pack.version?


### PR DESCRIPTION
Cosmetic bugfix.

Fixes #621
