### PR TITLE
:green_heart: fix failing 'converting TextMate' spec

### DIFF
--- a/src/text-mate-theme.coffee
+++ b/src/text-mate-theme.coffee
@@ -137,7 +137,7 @@ class TextMateTheme
         properties: @translateScopeSelectorSettings(settings)
 
   translateScopeSelector: (textmateScopeSelector) ->
-    new ScopeSelector(textmateScopeSelector).toCssSyntaxSelector()
+    new ScopeSelector(textmateScopeSelector).toCssSelector()
 
   translateScopeSelectorSettings: ({foreground, background, fontStyle}) ->
     properties = {}


### PR DESCRIPTION
```
apm init
  when creating a theme
    when converting a TextMate theme
      it generates the proper file structure
        Expected false to be truthy. (spec/init-spec.coffee:149:44)
        Expected false to be truthy. (spec/init-spec.coffee:150:65)
        Error: ENOENT: no such file or directory, open '/private/var/folders/nq/zkqqwby94lqc3vgm3z171wh40000gn/T/apm-init-116918-28371-a6sc9z/fake-theme/styles/syntax-variables.less'
          Error: ENOENT: no such file or directory, open '/private/var/folders/nq/zkqqwby94lqc3vgm3z171wh40000gn/T/apm-init-116918-28371-a6sc9z/fake-theme/styles/syntax-variables.less'
          at Error (native)
          at Object.fs.openSync (fs.js:549:18)
          at Object.fs.readFileSync (fs.js:397:15)
          at [object Object].<anonymous> (/Users/bronson/apm/spec/init-spec.coffee:151:21)
```

This is the commit that broke the test: https://github.com/atom/apm/commit/84f43104df2c8e091d143ab21b6c914b857e8be5
