### PR TITLE
Set `$RUSTUP_HOME` when running `npm` and `node-gyp`

### DIFF
--- a/spec/upgrade-spec.coffee
+++ b/spec/upgrade-spec.coffee
@@ -172,7 +172,7 @@ describe "apm upgrade", ->
     beforeEach ->
       delete process.env.ATOM_ELECTRON_URL
       delete process.env.ATOM_PACKAGES_URL
-      delete process.env.ATOM_ELECTRON_VERSION
+      process.env.ATOM_ELECTRON_VERSION = "0.22.0"
 
       gitRepo = path.join(__dirname, "fixtures", "test-git-repo.git")
       cloneUrl = "file://#{gitRepo}"

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -11,6 +11,12 @@ module.exports =
   getAtomDirectory: ->
     process.env.ATOM_HOME ? path.join(@getHomeDirectory(), '.atom')
 
+  getRustupHomeDirPath: ->
+    if process.env.RUSTUP_HOME
+      process.env.RUSTUP_HOME
+    else
+      path.join(@getHomeDirectory(), '.multirust')
+
   getCacheDirectory: ->
     path.join(@getAtomDirectory(), '.apm')
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -33,7 +33,7 @@ class Config extends Command
     configArgs = ['--globalconfig', apm.getGlobalConfigPath(), '--userconfig', apm.getUserConfigPath(), 'config']
     configArgs = configArgs.concat(options.argv._)
 
-    env = _.extend({}, process.env, HOME: @atomNodeDirectory)
+    env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: apm.getRustupHomeDirPath()})
     configOptions = {env}
 
     @fork @atomNpmPath, configArgs, configOptions, (code, stderr='', stdout='') ->

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -39,7 +39,7 @@ class Dedupe extends Command
     installNodeArgs.push("--arch=#{config.getElectronArch()}")
     installNodeArgs.push('--ensure')
 
-    env = _.extend({}, process.env, HOME: @atomNodeDirectory)
+    env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
     env.USERPROFILE = env.HOME if config.isWin32()
 
     fs.makeTreeSync(@atomDirectory)
@@ -83,7 +83,7 @@ class Dedupe extends Command
 
     dedupeArgs.push(packageName) for packageName in options.argv._
 
-    env = _.extend({}, process.env, HOME: @atomNodeDirectory)
+    env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
     env.USERPROFILE = env.HOME if config.isWin32()
     dedupeOptions = {env}
     dedupeOptions.cwd = options.cwd if options.cwd

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -67,7 +67,7 @@ class Install extends Command
     installNodeArgs.push("--ensure")
     installNodeArgs.push("--verbose") if @verbose
 
-    env = _.extend({}, process.env, HOME: @atomNodeDirectory)
+    env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
     env.USERPROFILE = env.HOME if config.isWin32()
 
     fs.makeTreeSync(@atomDirectory)
@@ -107,7 +107,7 @@ class Install extends Command
     if vsArgs = @getVisualStudioFlags()
       installArgs.push(vsArgs)
 
-    env = _.extend({}, process.env, HOME: @atomNodeDirectory)
+    env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
     @addBuildEnvVars(env)
     installOptions = {env}
     installOptions.streaming = true if @verbose
@@ -201,7 +201,7 @@ class Install extends Command
     if vsArgs = @getVisualStudioFlags()
       installArgs.push(vsArgs)
 
-    env = _.extend({}, process.env, HOME: @atomNodeDirectory)
+    env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
     @updateWindowsEnv(env) if config.isWin32()
     @addNodeBinToEnv(env)
     @addProxyToEnv(env)
@@ -428,7 +428,7 @@ class Install extends Command
       if vsArgs = @getVisualStudioFlags()
         buildArgs.push(vsArgs)
 
-      env = _.extend({}, process.env, HOME: @atomNodeDirectory)
+      env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
       @updateWindowsEnv(env) if config.isWin32()
       @addNodeBinToEnv(env)
       @addProxyToEnv(env)

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -52,7 +52,7 @@ class Rebuild extends Command
     if vsArgs = @getVisualStudioFlags()
       rebuildArgs.push(vsArgs)
 
-    env = _.extend({}, process.env, HOME: @atomNodeDirectory)
+    env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
     env.USERPROFILE = env.HOME if config.isWin32()
     @addBuildEnvVars(env)
 


### PR DESCRIPTION
This will make sure that overriding the `$HOME`/`$USERPROFILE` environment variable won't prevent tools like `cargo` or `rustc` from working appropriately on Windows. By default, we will honor the existing `$RUSTUP_HOME` if set, or set it to `$HOME/.multirust` (rustup's default) otherwise.

It's worth noting that an [RFC](https://github.com/rust-lang/rfcs/pull/1615) is being discussed to change the default rustup home directory to `~/.rustup`, so we'll probably need to change this default in the future in case that gets updated. I imagine that it will not happen without a reasonable notice, so we will have time to update such location. In addition, by the time the RFC gets approved and implemented, I am hoping we will have a better situation with respect to overriding the `$HOME` and `$USERPROFILE` variables, which is clearly suboptimal.

/cc: @nathansobo @maxbrunsfeld 