### PR TITLE
Fix build on Node 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ notifications:
     on_failure: change
 
 node_js:
-  - "0.10"
   - "4"
   - "6"
   - "7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ node_js:
   - "0.10"
   - "4"
   - "6"
+  - "7"
 
 script: ./bin/npm test
 

--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -7,6 +7,6 @@ if (process.platform.indexOf('win') === 0) {
 } else {
   script += '.sh'
 }
-var child = cp.spawn(script, [], {stdio: ['pipe', 'pipe', 'pipe']})
+var child = cp.spawn(script, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true })
 child.stderr.pipe(process.stderr)
 child.stdout.pipe(process.stdout)

--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -7,6 +7,6 @@ if (process.platform.indexOf('win') === 0) {
 } else {
   script += '.sh'
 }
-var child = cp.exec(script, [], {stdio: ['pipe', 'pipe', 'pipe']})
+var child = cp.spawn(script, [], {stdio: ['pipe', 'pipe', 'pipe']})
 child.stderr.pipe(process.stderr)
 child.stdout.pipe(process.stdout)


### PR DESCRIPTION
Use `child_process.spawn` instead of  `child_process.exec`.

Fixes #636