### PR TITLE
Ensure that native modules are built from source

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -111,7 +111,7 @@ class Command
       "--msvs_version=#{vsVersion}"
 
   getNpmBuildFlags: ->
-    ["--runtime=electron", "--target=#{@electronVersion}", "--dist-url=#{config.getElectronUrl()}", "--arch=#{config.getElectronArch()}"]
+    ["--runtime=electron", "--target=#{@electronVersion}", "--dist-url=#{config.getElectronUrl()}", "--arch=#{config.getElectronArch()}", "--build-from-source"]
 
   updateWindowsEnv: (env) ->
     env.USERPROFILE = env.HOME

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -110,6 +110,9 @@ class Command
     if vsVersion = config.getInstalledVisualStudioFlag()
       "--msvs_version=#{vsVersion}"
 
+  getNpmBuildFlags: ->
+    ["--runtime=electron", "--target=#{@electronVersion}", "--dist-url=#{config.getElectronUrl()}", "--arch=#{config.getElectronArch()}"]
+
   updateWindowsEnv: (env) ->
     env.USERPROFILE = env.HOME
 

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -33,10 +33,7 @@ class Dedupe extends Command
 
   installNode: (callback) ->
     installNodeArgs = ['install']
-    installNodeArgs.push("--runtime=electron")
-    installNodeArgs.push("--target=#{@electronVersion}")
-    installNodeArgs.push("--dist-url=#{config.getElectronUrl()}")
-    installNodeArgs.push("--arch=#{config.getElectronArch()}")
+    installNodeArgs.push(@getNpmBuildFlags()...)
     installNodeArgs.push('--ensure')
 
     env = _.extend({}, process.env, HOME: @atomNodeDirectory)
@@ -72,9 +69,7 @@ class Dedupe extends Command
 
   forkDedupeCommand: (options, callback) ->
     dedupeArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'dedupe']
-    dedupeArgs.push("--runtime=electron")
-    dedupeArgs.push("--target=#{@electronVersion}")
-    dedupeArgs.push("--arch=#{config.getElectronArch()}")
+    dedupeArgs.push(@getNpmBuildFlags()...)
     dedupeArgs.push('--silent') if options.argv.silent
     dedupeArgs.push('--quiet') if options.argv.quiet
 

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -60,10 +60,7 @@ class Install extends Command
 
   installNode: (callback) =>
     installNodeArgs = ['install']
-    installNodeArgs.push("--runtime=electron")
-    installNodeArgs.push("--target=#{@electronVersion}")
-    installNodeArgs.push("--dist-url=#{config.getElectronUrl()}")
-    installNodeArgs.push("--arch=#{config.getElectronArch()}")
+    installNodeArgs.push(@getNpmBuildFlags()...)
     installNodeArgs.push("--ensure")
     installNodeArgs.push("--verbose") if @verbose
 
@@ -96,9 +93,7 @@ class Install extends Command
 
     installArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'install']
     installArgs.push(modulePath)
-    installArgs.push("--runtime=electron")
-    installArgs.push("--target=#{@electronVersion}")
-    installArgs.push("--arch=#{config.getElectronArch()}")
+    installArgs.push(@getNpmBuildFlags()...)
     installArgs.push("--global-style") if installGlobally
     installArgs.push('--silent') if options.argv.silent
     installArgs.push('--quiet') if options.argv.quiet
@@ -191,9 +186,7 @@ class Install extends Command
 
   forkInstallCommand: (options, callback) ->
     installArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'install']
-    installArgs.push("--runtime=electron")
-    installArgs.push("--target=#{@electronVersion}")
-    installArgs.push("--arch=#{config.getElectronArch()}")
+    installArgs.push(@getNpmBuildFlags()...)
     installArgs.push('--silent') if options.argv.silent
     installArgs.push('--quiet') if options.argv.quiet
     installArgs.push('--production') if options.argv.production
@@ -421,9 +414,7 @@ class Install extends Command
 
       buildArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'build']
       buildArgs.push(path.resolve(__dirname, '..', 'native-module'))
-      buildArgs.push("--runtime=electron")
-      buildArgs.push("--target=#{@electronVersion}")
-      buildArgs.push("--arch=#{config.getElectronArch()}")
+      buildArgs.push(@getNpmBuildFlags()...)
 
       if vsArgs = @getVisualStudioFlags()
         buildArgs.push(vsArgs)

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -37,17 +37,9 @@ class Rebuild extends Command
   forkNpmRebuild: (options, callback) ->
     process.stdout.write 'Rebuilding modules '
 
-    rebuildArgs = [
-      '--globalconfig'
-      config.getGlobalConfigPath()
-      '--userconfig'
-      config.getUserConfigPath()
-      'rebuild'
-      '--runtime=electron'
-      "--target=#{@electronVersion}"
-      "--arch=#{config.getElectronArch()}"
-    ]
-    rebuildArgs = rebuildArgs.concat(options.argv._)
+    rebuildArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'rebuild']
+    rebuildArgs.push(@getNpmBuildFlags()...)
+    rebuildArgs.push(options.argv._...)
 
     if vsArgs = @getVisualStudioFlags()
       rebuildArgs.push(vsArgs)


### PR DESCRIPTION
This PR is build on top of #597 from @as-cii which makes this change much easier 👍 

Native modules relying on prebuilt binaries via [prebuild](https://github.com/mafintosh/prebuild) or [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) have to be [build from source against Electron headers](https://github.com/electron/electron/blob/master/docs/tutorial/using-native-node-modules.md#modules-that-rely-on-node-pre-gyp).

The `--build-from-source` flag ensures that they are built from source otherwise they wouldn't work with Atom.

/cc @rgbkrk