### PR TITLE
Determine remote from package.json

### DIFF
--- a/spec/packages-spec.coffee
+++ b/spec/packages-spec.coffee
@@ -1,0 +1,17 @@
+Packages = require '../lib/packages'
+
+describe 'getRemote', ->
+  it 'returns origin if remote could not be determined', ->
+    expect(Packages.getRemote()).toEqual('origin')
+
+  it 'returns repository.url', ->
+    pack =
+      repository:
+        type: 'git'
+        url: 'https://github.com/atom/apm.git'
+    expect(Packages.getRemote(pack)).toEqual(pack.repository.url)
+
+  it 'returns repository', ->
+    pack =
+      repository: 'https://github.com/atom/apm'
+    expect(Packages.getRemote(pack)).toEqual(pack.repository)

--- a/src/packages.coffee
+++ b/src/packages.coffee
@@ -13,3 +13,10 @@ module.exports =
       [name, owner] = repoPath.split('/')[-2..]
       return "#{name}/#{owner}" if name and owner
     null
+
+  # Determine remote from package metadata.
+  #
+  # pack - The package metadata object.
+  # Returns a the remote or 'origin' if not parseable.
+  getRemote: (pack={}) ->
+    pack.repository?.url or pack.repository or 'origin'

--- a/src/publish.coffee
+++ b/src/publish.coffee
@@ -65,11 +65,12 @@ class Publish extends Command
   # Push a tag to the remote repository.
   #
   #  tag - The tag to push.
+  #  pack - The package metadata.
   #  callback - The callback function to invoke with an error as the first
   #             argument.
-  pushVersion: (tag, callback) ->
+  pushVersion: (tag, pack, callback) ->
     process.stdout.write "Pushing #{tag} tag "
-    pushArgs = ['push', 'origin', 'HEAD', tag]
+    pushArgs = ['push', Packages.getRemote(pack), 'HEAD', tag]
     @spawn 'git', pushArgs, (args...) =>
       @logCommandResults(callback, args...)
 
@@ -350,7 +351,7 @@ class Publish extends Command
           @versionPackage version, (error, tag) =>
             return callback(error) if error?
 
-            @pushVersion tag, (error) =>
+            @pushVersion tag, pack, (error) =>
               return callback(error) if error?
 
               @waitForTagToBeAvailable pack, tag, =>


### PR DESCRIPTION
I often have repositories where the "official" remote isn't `origin`. Most of the time the desired remote would be named `upstream` or similar.

To publish a new version one needs to make sure that `origin` points to the upstream repo where the package should be publish. This behavior can sometimes be very anoying.

This PR will determine the remote from the `package.json` file and fall back to `origin`.
Fixes #343