### PR TITLE
Fix "Installing modules failed" on Atom

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -125,10 +125,11 @@ class Command
 
   addNodeBinToEnv: (env) ->
     nodeBinFolder = path.resolve(__dirname, '..', 'bin')
-    if env['PATH']
-      env['PATH'] = "#{nodeBinFolder}#{path.delimiter}#{env['PATH']}"
+    pathKey = if config.isWin32() then 'Path' else 'PATH'
+    if env[pathKey]
+      env[pathKey] = "#{nodeBinFolder}#{path.delimiter}#{env[pathKey]}"
     else
-      env['PATH']= nodeBinFolder
+      env[pathKey]= nodeBinFolder
 
   addProxyToEnv: (env) ->
     httpProxy = @npm.config.get('proxy')


### PR DESCRIPTION
I have **winreg** on **package.json** (Atom) linked to **github:jsolisu/node-winreg**, when i use: _script\build_ or _script\bootstrap_ APM fails with _"Installing modoles failed..."_

The problem is because PATH is undefined. I revert changes from 1.15.0 using 1.14.1 version of _command.coffee_

[npm-debug.log.txt](https://github.com/atom/apm/files/587501/npm-debug.log.txt)
