### PR TITLE
 Convert "latest" tag to latest version

### DIFF
--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -174,6 +174,21 @@ describe 'apm install', ->
             expect(fs.existsSync(packageDirectory)).toBeFalsy()
             expect(callback.mostRecentCall.args[0]).not.toBeNull()
 
+    describe 'when a package version is specified', ->
+      it 'installs the specified version', ->
+        testModuleDirectory = path.join(atomHome, 'packages', 'test-module2')
+
+        callback = jasmine.createSpy('callback')
+        apm.run(['install', 'test-module2@2.0.0'], callback)
+
+        waitsFor 'waiting for install to complete', 600000, ->
+          callback.callCount is 1
+
+        runs ->
+          expect(callback.mostRecentCall.args[0]).toBeNull()
+          expect(fs.existsSync(path.join(testModuleDirectory, 'package.json'))).toBeTruthy()
+          expect(JSON.parse(fs.readFileSync(path.join(testModuleDirectory, 'package.json'))).version).toBe "2.0.0"
+
     describe 'when multiple package names are specified', ->
       it 'installs all packages', ->
         testModuleDirectory = path.join(atomHome, 'packages', 'test-module')

--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -189,6 +189,21 @@ describe 'apm install', ->
           expect(fs.existsSync(path.join(testModuleDirectory, 'package.json'))).toBeTruthy()
           expect(JSON.parse(fs.readFileSync(path.join(testModuleDirectory, 'package.json'))).version).toBe "2.0.0"
 
+    describe 'when the "latest"-tag is specified', ->
+      it 'installs the latest version', ->
+        testModuleDirectory = path.join(atomHome, 'packages', 'test-module2')
+
+        callback = jasmine.createSpy('callback')
+        apm.run(['install', 'test-module2@latest'], callback)
+
+        waitsFor 'waiting for install to complete', 600000, ->
+          callback.callCount is 1
+
+        runs ->
+          expect(callback.mostRecentCall.args[0]).toBeNull()
+          expect(fs.existsSync(path.join(testModuleDirectory, 'package.json'))).toBeTruthy()
+          expect(JSON.parse(fs.readFileSync(path.join(testModuleDirectory, 'package.json'))).version).toBe "2.0.0"
+
     describe 'when multiple package names are specified', ->
       it 'installs all packages', ->
         testModuleDirectory = path.join(atomHome, 'packages', 'test-module')

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -336,6 +336,9 @@ class Install extends Command
           callback("No available version compatible with the installed Atom version: #{@installedAtomVersion}")
           return
 
+        if not pack.versions[packageVersion]? and packageVersion is 'latest'
+          packageVersion = @getLatestCompatibleVersion(pack)
+
         {tarball} = pack.versions[packageVersion]?.dist ? {}
         unless tarball
           @logFailure()


### PR DESCRIPTION
This allows ([just as npm](https://docs.npmjs.com/cli/install)) the use of the "latest"-tag like `apm install apm@latest`.