### PR TITLE
Update Electron headers URL

### DIFF
--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -54,7 +54,7 @@ module.exports =
     process.env.ATOM_REPOS_HOME ? path.join(@getHomeDirectory(), 'github')
 
   getElectronUrl: ->
-    process.env.ATOM_ELECTRON_URL ? 'https://atom.io/download/atom-shell'
+    process.env.ATOM_ELECTRON_URL ? 'https://atom.io/download/electron'
 
   getAtomPackagesUrl: ->
     process.env.ATOM_PACKAGES_URL ? "#{@getAtomApiUrl()}/packages"


### PR DESCRIPTION
Both URLs are still available and serve the same assets, but this one uses the new name for Electron, not the old one Atom Shell.
