### PR TITLE
Replacing async.map with async.mapLimit to adress #641

### DIFF
--- a/src/upgrade.coffee
+++ b/src/upgrade.coffee
@@ -129,7 +129,7 @@ class Upgrade extends Command
         @getLatestVersion pack, (err, latestVersion) ->
           done(err, {pack, latestVersion})
 
-    async.map packages, getLatestVersionOrSha, (error, updates) ->
+    async.mapLimit packages, 10, getLatestVersionOrSha, (error, updates) ->
       return callback(error) if error?
 
       updates = _.filter updates, (update) -> update.latestVersion? or update.sha?


### PR DESCRIPTION
### Description of the Change

Using `async.map` to get the latest versions for all packages probably fires hundreds of simultaneous requests to the webserver (depending on how many packages are installed). Replacing this with `async.mapLimit` ensures that only (in this case) 10 connections are made at once.

### Alternate Designs

No alternates came in mind since async was already the right tool for the job.

### Benefits

Preventing the client from having to open too many simultaneous connections opened which caused real problems for some users which resulting in updates not working at all.

### Possible Drawbacks

Theoretically it could result in a slower update process since we're only requesting information for a maximum of 10 packages at once. Seeing the current problem of people not be able to update at all this might be a drawback they'll likely accept.

### Applicable Issues

Fixes #641 
