### PR TITLE
Wait 10s for the tag to be found on `apm publish`

### DIFF
--- a/src/publish.coffee
+++ b/src/publish.coffee
@@ -76,7 +76,7 @@ class Publish extends Command
   # Check for the tag being available from the GitHub API before notifying
   # atom.io about the new version.
   #
-  # The tag is checked for 5 times at 1 second intervals.
+  # The tag is checked for 10 times at 1 second intervals.
   #
   # pack - The package metadata.
   # tag - The tag that was pushed.
@@ -84,7 +84,7 @@ class Publish extends Command
   #            or the maximum numbers of requests for the tag have been made.
   #            No arguments are passed to the callback when it is invoked.
   waitForTagToBeAvailable: (pack, tag, callback) ->
-    retryCount = 5
+    retryCount = 10
     interval = 1000
     requestSettings =
       url: "https://api.github.com/repos/#{Packages.getRepository(pack)}/tags"


### PR DESCRIPTION
### Description of the Change

Wait 10s for the tag to be found on `apm publish`. I think there are situations where [5s](https://github.com/atom/apm/blob/89ea28bd940388010606302fa97f4193efa0b0cf/src/publish.coffee#L79) is not enough, especially when Atom has to authenticate with GH.  https://discuss.atom.io/t/cant-publish-package/4890/16?u=joshcheek

### Alternate Designs

I did not consider alternatives as I don't know how to reproduce the original issue as I don't know the cause for a fact.


### Benefits

This will still work as soon as the tag is found, but will longer if it hasn't been found yet. This should be a rare use case, so I don't expect it to add much overhead, but when it goes wrong, it's difficult to figure out what to do (perhaps a --retry) flag, so increasing the time limit will save a lot of frustration in that case (assuming the it just took longer than the timeout).


### Possible Drawbacks

1. While I suspect that the timeout duration is the cause of the issue linked above,
   I do not know this for a fact (I haven't reproduced it as I don't know the cause)
2. No tests exercise this code. On `./bin/npm test`, all tests pass with this change
   but no tests fail when I add a throw statement on the line above. Seems benign enough,
   but maybe look it over more seriously for that reason


### Applicable Issues

* A list of users with this issue + desc of what I noticed when I hit it https://discuss.atom.io/t/cant-publish-package/4890/16?u=joshcheek
* This person hit it, it "resolved itself", so probably a longer timeout would have prevented them from having the issue, saving all the work they put into trying to fix it, and the maintainers getting an issue opened when it wasn't really broken https://github.com/atom/apm/issues/670
* +1 on [this](https://github.com/atom/apm/issues/558) issue, if this happened, it would probably not be so painful on a failure here (meaning I'd have immediately repushed, accomplishing the same thing as a timeout. That said, making it atomic is nontrivial as it's already pushed the tags to github.
* +1 to [this](https://github.com/atom/apm/issues/459) issue, as well, I didn't see any way to tell it to try again until I found and read through [this](https://discuss.atom.io/t/cant-publish-package/4890/16?u=joshcheek) whole thread, and then when I did finally understand to use the `--tag` option, I used it wrong (I did `--tag 2.2.2` rather than `--tag v2.2.2`), it seems there are dozens of people who all want to do this but have to go to the internet to find it, and even then it's error prone. Increasing the timeout will hopefully reduce the number of people, but still, why not add a `--retry` flag that maps to `--tag {currentVersion}` 
* Probably would fix this issue: https://github.com/atom/apm/issues/422
* Note that there are two more pages of issues about publishing that I haven't yet looked through (it's a bit tedious, and I feel like the point is already made).