### PR TITLE
Make python-interceptor.sh respect PYTHON env variable

### DIFF
--- a/bin/python-interceptor.sh
+++ b/bin/python-interceptor.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PYTHON="${PYTHON:-python}" #Set default value
 
 case $1 in
   */gyp_main.py)
@@ -34,9 +35,9 @@ case $1 in
       ARGS+=("--format=safemake.py")
     fi
 
-    exec python "${ARGS[@]}"
+    exec "$PYTHON" "${ARGS[@]}"
     ;;
   *)
-    exec python "$@"
+    exec "$PYTHON" "$@"
     ;;
 esac


### PR DESCRIPTION
### Description of the Change

This should (at least in theory) make the whole thing work on systems with dual Python installations (i.e. both Python 2 and Python 3), provided `PYTHON` environment variable points to the correct one (e.g. `python2`). This works with node-gyp, so I see no reason why this shouldn't work for apm as well.

### Alternate Designs

Not aware of any alternatives, besides alternative syntax for default value definition. Could use `: ${PYTHON:=python}` instead of assignment, but I find current version more intuitive.

### Benefits

Support systems where system `python` executable points to Python 3.

### Possible Drawbacks

Not aware of any.

### Applicable Issues

None I could find.