### PR TITLE
Remove obsolete .marker and .search-results CSS rules

### DIFF
--- a/src/text-mate-theme.coffee
+++ b/src/text-mate-theme.coffee
@@ -102,17 +102,6 @@ class TextMateTheme
         'color': '@syntax-invisible-character-color'
 
     @rulesets.push
-      selector: 'atom-text-editor .search-results .marker .region'
-      properties:
-        'background-color': 'transparent'
-        'border': '@syntax-result-marker-color'
-
-    @rulesets.push
-      selector: 'atom-text-editor .search-results .marker.current-result .region'
-      properties:
-        'border': '@syntax-result-marker-color-selected'
-
-    @rulesets.push
       selector: 'atom-text-editor.is-focused .cursor'
       properties:
         'border-color': '@syntax-cursor-color'

--- a/templates/theme/styles/base.less
+++ b/templates/theme/styles/base.less
@@ -51,15 +51,6 @@ atom-text-editor {
   }
 }
 
-atom-text-editor .search-results .marker .region {
-  background-color: transparent;
-  border: 1px solid @syntax-result-marker-color;
-}
-
-atom-text-editor .search-results .marker.current-result .region {
-  border: 1px solid @syntax-result-marker-color-selected;
-}
-
 
 // Syntax styles
 


### PR DESCRIPTION
### Description of the Change

If we get a textmate theme (e.g. https://raw.githubusercontent.com/JetBrains/colorSchemeTool/master/tmThemes/Monokai.tmTheme).

And try to convert it to an atom theme using apm as shown in the docs:
http://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate/

The resulting theme (if we chose it as the current syntax theme on settings) will display a deprecation warning about two class selectors:

> Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:
> 
> atom-text-editor .search-results .marker .region => atom-text-editor .search-results .syntax--marker .region
> atom-text-editor .search-results .marker.current-result .region => atom-text-editor .search-results .syntax--marker.current-result .region
> Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible.

#### Screenshot of the deprecation message
![deprecation-screenshot](https://cloud.githubusercontent.com/assets/2272928/23588842/6b95c996-0191-11e7-8ae4-39089d9dbd91.png)

But, as it was discussed in this PR: https://github.com/atom/atom/pull/13934, in these two comments: https://github.com/atom/atom/pull/13934#issuecomment-284648577 and https://github.com/atom/atom/pull/13934#issuecomment-284667580.

Atom doesn't use the `.marker` and `.search-results` with those specific rules anymore. So, they are obsolete now and safe to delete.

### Alternate Designs

This PR: https://github.com/atom/atom/pull/13934 considered removing `.marker` from the deprecated syntax selectors, but at least one language package needed it to be in that list (https://github.com/atom/atom/pull/13934#issuecomment-284430507).

### Benefits

All themes that are automatically converted with the official atom "way" (using apm) are currently displaying deprecation warnings and also triggering some unnecessary automatic selector translations. This PR fixes that.

### Possible Drawbacks

None.

### Applicable Issues

None.
