### PR TITLE
Respect a user's PYTHON or npm_config_python settings

### DIFF
--- a/bin/apm
+++ b/bin/apm
@@ -28,10 +28,26 @@ binDir=`pwd -P`
 maybe_node_gyp_path="$binDir"/../node_modules/.bin/node-gyp
 if [ -e "$maybe_node_gyp_path" ]
 then
+  # Prevent vars like NODE_CONFIG_NODE_GYP from messing this up
+  for var in $(env | grep -i ^npm_config_node_gyp=)
+  do
+    unset ${var%%=*}
+  done
+
   export npm_config_node_gyp="$maybe_node_gyp_path"
 fi
 
-export PYTHON="${binDir}/python-interceptor.sh"
+export ATOM_APM_ORIGINAL_PYTHON="${PYTHON:-}"
+
+# Assumption: env iterates through environment variables in the same order that
+# process.env iterates through properties within npm. So, we take the last match.
+for var in $(env | grep -i ^npm_config_python=)
+do
+  ATOM_APM_ORIGINAL_PYTHON="${var#*=}"
+  unset ${var%%=*}
+done
+
+export npm_config_python="${SCRIPT_DIR}/python-interceptor.sh"
 
 builtin cd "$initialCwd"
 "$binDir/$nodeBin" "$binDir/../lib/cli.js" "$@"

--- a/bin/npm
+++ b/bin/npm
@@ -2,11 +2,30 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export PATH="$SCRIPT_DIR:$PATH"
 
-export PYTHON="${SCRIPT_DIR}/python-interceptor.sh"
+export ATOM_APM_ORIGINAL_PYTHON="${PYTHON:-}"
+
+# Assumption: env iterates through environment variables in the same order that
+# process.env iterates through properties within npm. So, we take the last match.
+for var in $(env | grep -i ^npm_config_python=)
+do
+  ATOM_APM_ORIGINAL_PYTHON="${var#*=}"
+done
+if [ -z "${ATOM_APM_ORIGINAL_PYTHON}" ] && [ -n "${PYTHON:-}" ]
+then
+  ATOM_APM_ORIGINAL_PYTHON="${PYTHON}"
+fi
+
+export npm_config_python="${SCRIPT_DIR}/python-interceptor.sh"
 
 maybe_node_gyp_path="$SCRIPT_DIR"/../node_modules/.bin/node-gyp
 if [ -e "$maybe_node_gyp_path" ]
 then
+  # Prevent vars like NODE_CONFIG_NODE_GYP from messing this up
+  for var in $(env | grep -i ^npm_config_node_gyp=)
+  do
+    unset ${var%%=*}
+  done
+
   export npm_config_node_gyp="$maybe_node_gyp_path"
 fi
 

--- a/spec/fixtures/fake-python-1.sh
+++ b/spec/fixtures/fake-python-1.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "fake-python-1 called" >&2
+exit 1

--- a/spec/fixtures/fake-python-2.sh
+++ b/spec/fixtures/fake-python-2.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "fake-python-2 called" >&2
+exit 1

--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -498,3 +498,46 @@ describe 'apm install', ->
 
           makefileContent = fs.readFileSync(path.join(testModuleDirectory, 'build', 'Makefile'), {encoding: 'utf-8'})
           expect(makefileContent).toMatch('node_modules/with\\ a\\ space/addon.gypi')
+
+    describe "configurable Python binaries", ->
+      nodeModules = fs.realpathSync(path.join(__dirname, '..', 'node_modules'))
+      [originalPython, originalNpmConfigPython] = []
+
+      beforeEach ->
+        originalPython = process.env.PYTHON
+        originalNpmConfigPython = process.env.npm_config_python
+        delete process.env.PYTHON
+        delete process.env.npm_config_python
+
+      afterEach ->
+        process.env.PYTHON = originalPython
+        process.env.npm_config_python = originalNpmConfigPython
+
+      it 'respects ${PYTHON} if set', ->
+        process.env.PYTHON = path.join __dirname, 'fixtures', 'fake-python-1.sh'
+
+        callback = jasmine.createSpy('callback')
+        apm.run(['install', 'native-package'], callback)
+
+        waitsFor 'waiting for install to fail', 600000, ->
+          callback.callCount is 1
+
+        runs ->
+          errorText = callback.mostRecentCall.args[0]
+          expect(errorText).not.toBeNull()
+          expect(errorText).toMatch('fake-python-1 called')
+
+      it 'respects ${npm_config_python} if set', ->
+        process.env.npm_config_python = path.join __dirname, 'fixtures', 'fake-python-2.sh'
+        process.env.PYTHON = path.join __dirname, 'fixtures', 'fake-python-1.sh'
+
+        callback = jasmine.createSpy('callback')
+        apm.run(['install', 'native-package'], callback)
+
+        waitsFor 'waiting for install to fail', 600000, ->
+          callback.callCount is 1
+
+        runs ->
+          errorText = callback.mostRecentCall.args[0]
+          expect(errorText).not.toBeNull()
+          expect(errorText).toMatch('fake-python-2 called')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This captures the various ways that node-gyp can find its Python executable within the entrypoint scripts and forwards them to the Python interceptor script as `ATOM_APM_ORIGINAL_PYTHON`. python-interceptor then execs `ATOM_APM_ORIGINAL_PYTHON` instead of a hardcoded "python".

Furthermore, this deals with some odd edge cases related to `npm` being _case-insensitive_ when it reads `npm_config_*` variables from its environment. If a user had something like `NPM_CONFIG_PYTHON` or `npm_CONFIG_node_GYP` set in their environment the results would technically be undefined. 🌈 

### Alternate Designs

I considered using `npm config set` and `npm config get` to use npm itself for precedence rules, but `npm config get` reported "undefined" for unset variables instead of a blank string (and returns with a 0 status), which makes it awkward to use in scripts.

### Benefits

#673 introduced a regression: apm no longer respects a user's external `PYTHON` or `npm_config_python` settings. This causes problems on systems where the default Python executable is not compatible with node-gyp. With this change, those settings are respected in a way which is consistent with the behavior of a plain`npm install`.

### Possible Drawbacks

This uses bash syntax pattern substitution constructs like `${..##}` and `${..%%}` which may not be portable to all shell environments. The shebang in our `apm` and `npm` scripts was already `#!/bin/bash`, though, so we should be no less portable than we were before.

### Applicable Issues

Fixes #698.
