### PR TITLE
:bug: Fix cleaning of scoped packages

### DIFF
--- a/spec/clean-spec.coffee
+++ b/spec/clean-spec.coffee
@@ -52,3 +52,17 @@ describe 'apm clean', ->
     runs ->
       expect(callback.mostRecentCall.args[0]).toBeUndefined()
       expect(fs.existsSync(removedPath)).toBeFalsy()
+
+  it 'uninstalls a scoped package', ->
+    removedPath = path.join(moduleDirectory, 'node_modules', '@types/atom')
+    fs.makeTreeSync(removedPath)
+
+    callback = jasmine.createSpy('callback')
+    apm.run(['clean'], callback)
+
+    waitsFor 'waiting for command to complete', ->
+      callback.callCount > 0
+
+    runs ->
+      expect(callback.mostRecentCall.args[0]).toBeUndefined()
+      expect(fs.existsSync(removedPath)).toBeFalsy()

--- a/src/clean.coffee
+++ b/src/clean.coffee
@@ -39,15 +39,34 @@ class Clean extends Command
 
     modulesToRemove = []
     modulesPath = path.resolve('node_modules')
-    installedModules = fs.list(modulesPath).filter (modulePath) ->
+    modulePathFilter = (modulePath) ->
       modulePath isnt '.bin' and modulePath isnt 'atom-package-manager'
+    installedModules = fs.list(modulesPath).filter modulePathFilter
+
+    # Check if the module is a scoped module (starting with an '@')
+    # If so, recursively lookup inside this directory
+    # and concatenate to the root folder
+    #
+    # e.g. if you have a dependency @types/atom, modulePath === @types
+    # fs.list(@types) === ['atom'], thus this will return ['@types/atom']
+    #
+    # At the end, flat map, since these scoped packages can return more than 1
+    # and normal modules return only 1
+    filteredInstalledModules = [].concat.apply([], installedModules.map (modulePath) ->
+      if not (modulePath.substring(0, 1) is '@')
+        [modulePath]
+      else
+        fs.list(path.join(modulesPath, modulePath)).filter modulePathFilter
+          .map (subPath) ->
+            path.join(modulePath, subPath)
+    )
 
     # Find all dependencies of all installed modules recursively
-    for installedModule in installedModules
+    for installedModule in filteredInstalledModules
       @getDependencies(path.join(modulesPath, installedModule), dependencies)
 
     # Only remove dependencies that aren't referenced by any installed modules
-    for installedModule in installedModules
+    for installedModule in filteredInstalledModules
       continue if dependencies.hasOwnProperty(installedModule)
       continue if devDependencies.hasOwnProperty(installedModule)
       continue if packageDependencies.hasOwnProperty(installedModule)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Scoped packages put dependencies in a sub-folder. Therefore if a scoped package is encountered, recursively iterate through the directory to correctly resolve the scoped name.

### Alternate Designs

Keeping track of the scoped packages, but that would be very memory intensive.

### Benefits

It no longer infinitely loops when a scoped packages is installed in `node_modules`

### Possible Drawbacks

Maybe a little bit slower, but I don't think that is a too big of an issue.

### Applicable Issues

Fixes #702