### PR TITLE
Upgrade to keytar@4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+dist: trusty
+sudo: required
 
 notifications:
   email:
@@ -18,8 +20,6 @@ git:
 branches:
   only:
     - master
-
-sudo: false
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ branches:
 addons:
   apt:
     packages:
-      - libsecret-1-0
+      - libsecret-1-dev
       - g++-4.8
     sources:
       - ubuntu-toolchain-r-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ sudo: false
 addons:
   apt:
     packages:
-      - libgnome-keyring-dev
+      - libsecret-1-0
       - g++-4.8
     sources:
       - ubuntu-toolchain-r-test

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fs-plus": "2.x",
     "git-utils": "^4.0",
     "hosted-git-info": "^2.1.4",
-    "keytar": "^3.0",
+    "keytar": "^4.0",
     "mv": "2.0.0",
     "ncp": "~0.5.1",
     "npm": "3.10.5",

--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -17,21 +17,22 @@ module.exports =
   # callback - A function to call with an error as the first argument and a
   #            string token as the second argument.
   getToken: (callback) ->
-    if token = keytar.findPassword(tokenName)
-      callback(null, token)
-      return
+    keytar.findPassword(tokenName).then (token) ->
+      if token
+        callback(null, token)
+        return
 
-    if token = process.env.ATOM_ACCESS_TOKEN
-      callback(null, token)
-      return
+      if token = process.env.ATOM_ACCESS_TOKEN
+        callback(null, token)
+        return
 
-    callback """
-      No Atom.io API token in keychain
-      Run `apm login` or set the `ATOM_ACCESS_TOKEN` environment variable.
-    """
+      callback """
+        No Atom.io API token in keychain
+        Run `apm login` or set the `ATOM_ACCESS_TOKEN` environment variable.
+      """
 
   # Save the given token to the keychain.
   #
   # token - A string token to save.
   saveToken: (token) ->
-    keytar.replacePassword(tokenName, 'atom.io', token)
+    keytar.setPassword(tokenName, 'atom.io', token)


### PR DESCRIPTION
This PR upgrades apm to use keytar v4.x, which implements an async API.

The code paths that required fetching data from keytar already took a callback (even though they were synchronous) so updating was straightforward.

libgnome-keyring-dev is no longer needed on Travis, and is replaced with libsecret.