### PR TITLE
 Run APM from Windows Subsystem for Linux

### DIFF
--- a/bin/apm
+++ b/bin/apm
@@ -12,6 +12,8 @@ binDir=`basename "$apmPath"`
 osName=`uname -s`
 if [ "${osName:0:10}" == 'MINGW32_NT' ]; then
   nodeBin="node.exe"
+elif [[ $(uname -r) == *-Microsoft ]]; then
+  nodeBin="node.exe"
 else
   nodeBin="node"
 fi
@@ -33,5 +35,12 @@ fi
 
 export PYTHON="${binDir}/python-interceptor.sh"
 
-builtin cd "$initialCwd"
-"$binDir/$nodeBin" "$binDir/../lib/cli.js" "$@"
+cliPath="$binDir/../lib/cli.js"
+if [[ $(uname -r) == *-Microsoft ]]; then
+  cliPath="$(echo $cliPath | sed 's/\/mnt\/\([a-z]*\)\(.*\)/\1:\2/')"
+  cliPath="${cliPath////\\}"
+else
+  builtin cd "$initialCwd"
+fi
+
+"$binDir/$nodeBin" "$cliPath" "$@"


### PR DESCRIPTION
Correctly launch the Windows native version of APM from the Windows Subsystem for Linux (WSL)

Fixes https://github.com/atom/atom/issues/14258 along with https://github.com/atom/atom/pull/14287 for Atom