### PR TITLE
npm version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "keytar": "^4.0",
     "mv": "2.0.0",
     "ncp": "~0.5.1",
-    "npm": "3.10.5",
+    "npm": "3.10.10",
     "open": "0.0.4",
     "plist": "git+https://github.com/nathansobo/node-plist.git",
     "q": "~0.9.7",


### PR DESCRIPTION
Updating the bundled version of npm to avoid npm/npm#13256, which was breaking the installation of packages with native dependencies.