### PR TITLE
add `apm link --name` option

### DIFF
--- a/spec/link-spec.coffee
+++ b/spec/link-spec.coffee
@@ -155,3 +155,30 @@ describe 'apm link/unlink', ->
 
       runs ->
         expect(fs.existsSync(path.join(atomHome, 'packages', path.basename(numericPackageName)))).toBeFalsy()
+
+  describe "when the package name is set after --name", ->
+    it "still links and unlinks normally", ->
+      atomHome = temp.mkdirSync('apm-home-dir-')
+      process.env.ATOM_HOME = atomHome
+      packagePath = temp.mkdirSync('new-package')
+      packageName = 'new-package-name'
+      callback = jasmine.createSpy('callback')
+
+      runs ->
+        apm.run(['link', packagePath, '--name', packageName], callback)
+
+      waitsFor 'link to complete', ->
+        callback.callCount is 1
+
+      runs ->
+        expect(fs.existsSync(path.join(atomHome, 'packages', packageName))).toBeTruthy()
+        expect(fs.realpathSync(path.join(atomHome, 'packages', packageName))).toBe fs.realpathSync(packagePath)
+
+        callback.reset()
+        apm.run(['unlink', packageName], callback)
+
+      waitsFor 'unlink to complete', ->
+        callback.callCount is 1
+
+      runs ->
+        expect(fs.existsSync(path.join(atomHome, 'packages', packageName))).toBeFalsy()

--- a/src/link.coffee
+++ b/src/link.coffee
@@ -15,7 +15,7 @@ class Link extends Command
     options = yargs(argv).wrap(100)
     options.usage """
 
-      Usage: apm link [<package_path>]
+      Usage: apm link [<package_path>] [--name <package_name>]
 
       Create a symlink for the package in ~/.atom/packages. The package in the
       current working directory is linked if no path is given.
@@ -32,8 +32,9 @@ class Link extends Command
     packagePath = options.argv._[0]?.toString() ? '.'
     linkPath = path.resolve(process.cwd(), packagePath)
 
+    packageName = options.argv.name
     try
-      packageName = CSON.readFileSync(CSON.resolve(path.join(linkPath, 'package'))).name
+      packageName = CSON.readFileSync(CSON.resolve(path.join(linkPath, 'package'))).name unless packageName
     packageName = path.basename(linkPath) unless packageName
 
     if options.argv.dev


### PR DESCRIPTION
### Description of the Change

Add a `--name` option to `apm link`

```
apm link [<package_path>] [--name <package_name>]
```

### Alternate Designs

We could also add the `-n` short option

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

- Set the name of a linked package easily
- Being able to have two versions of the same package (Most likely one of them disabled based on context)
- Overriding a core package with a local package

Right now the way to do this is to change the `name` field in `package.json`, then link the package, then change the `name` field back.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

none?

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

none
<!-- Enter any applicable Issues here -->
