### PR TITLE
use Python 2.x explicitly for node-gyp compat

### DIFF
--- a/bin/python-interceptor.sh
+++ b/bin/python-interceptor.sh
@@ -34,9 +34,9 @@ case $1 in
       ARGS+=("--format=safemake.py")
     fi
 
-    exec python "${ARGS[@]}"
+    exec python2 "${ARGS[@]}"
     ;;
   *)
-    exec python "$@"
+    exec python2 "$@"
     ;;
 esac


### PR DESCRIPTION
### Description of the Change

If you have installed Python 3 and it is your default `python`, then installing some packages will fail.  This change fixes the ambiguity by using the `python2` command that is available and will always use Python 2.x

#### When `python` is version 3.x
```shell
➜  ~ apm --version
apm  1.18.1
npm  3.10.10
node 6.9.5 x64
python 3.6.1
git 2.11.0
➜  ~ apm install term3
Installing term3 to /Users/dholdren/.atom/packages ✗

> ptyw.js@0.4.1 install /private/var/folders/q4/503myxfn11z2hrmywy0zhmr00000gn/T/apm-install-dir-117612-85525-asrw3u.lx7f7ds4i/node_modules/term3/node_modules/ptyw.js
> node-gyp rebuild

/private/var/folders/q4/503myxfn11z2hrmywy0zhmr00000gn/T/apm-install-dir-117612-85525-asrw3u.lx7f7ds4i
└── (empty)


npm WARN deprecated react-tools@0.11.2: react-tools is deprecated. For more information, visit https://fb.me/react-tools-deprecated
npm WARN deprecated graceful-fs@2.0.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
gyp WARN download NVM_IOJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use IOJS_ORG_MIRROR
gyp ERR! configure error
gyp ERR! stack Error: Python executable "/Applications/Atom.app/Contents/Resources/app/apm/bin/python-interceptor.sh" is v3.6.1, which is not supported by gyp.
gyp ERR! stack You can pass the --python switch to point to Python >= v2.5.0 & < 3.0.0.
gyp ERR! stack     at failPythonVersion (/Applications/Atom.app/Contents/Resources/app/apm/node_modules/node-gyp/lib/configure.js:454:14)
gyp ERR! stack     at /Applications/Atom.app/Contents/Resources/app/apm/node_modules/node-gyp/lib/configure.js:443:9
gyp ERR! stack     at ChildProcess.exithandler (child_process.js:197:7)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:191:7)
gyp ERR! stack     at maybeClose (internal/child_process.js:877:16)
gyp ERR! stack     at Socket.<anonymous> (internal/child_process.js:334:11)
gyp ERR! stack     at emitOne (events.js:96:13)
gyp ERR! stack     at Socket.emit (events.js:188:7)
gyp ERR! stack     at Pipe._handle.close [as _onclose] (net.js:498:12)
gyp ERR! System Darwin 16.6.0
gyp ERR! command "/Applications/Atom.app/Contents/Resources/app/apm/bin/node" "/Applications/Atom.app/Contents/Resources/app/apm/node_modules/.bin/node-gyp" "rebuild"
```
#### When `python` is version 2.x
```shell
➜  ~ pyenv global system
➜  ~ python --version
Python 2.7.13
➜  ~ apm --version
apm  1.18.1
npm  3.10.10
node 6.9.5 x64
python 2.7.13
git 2.11.0
➜  ~ apm install term3
Installing term3 to /Users/dholdren/.atom/packages ✓
```

### Benefits

This will allow installing packages that use `gyp` when the system Python is version 3.x

### Applicable Issues

https://github.com/atom/apm/issues/698
https://github.com/Floobits/atom-term3/issues/88
