### PR TITLE
Textmate conversion error reporting & apm list --enabled

### DIFF
--- a/spec/list-spec.coffee
+++ b/spec/list-spec.coffee
@@ -110,9 +110,9 @@ describe 'apm list', ->
 
     listPackages ['--enabled'], ->
       expect(console.log.argsForCall[1][0]).toContain 'test2-module@1.0.0'
-      expect(console.log.argsForCall[3][0]).toContain 'dev-package@1.0.0'
-      expect(console.log.argsForCall[6][0]).toContain 'user-package@1.0.0'
-      expect(console.log.argsForCall[9][0]).toContain 'git-package@1.0.0'
+      expect(console.log.argsForCall[4][0]).toContain 'dev-package@1.0.0'
+      expect(console.log.argsForCall[7][0]).toContain 'user-package@1.0.0'
+      expect(console.log.argsForCall[10][0]).toContain 'git-package@1.0.0'
 
   it 'lists packages in json format when --json is passed', ->
     listPackages ['--json'], ->

--- a/spec/list-spec.coffee
+++ b/spec/list-spec.coffee
@@ -88,7 +88,19 @@ describe 'apm list', ->
     listPackages [], ->
       expect(console.log.argsForCall[1][0]).toContain 'test-module@1.0.0 (disabled)'
 
-  it 'displays only enabled packages --enabled is called', ->
+  it 'displays only enabled packages when --enabled is called', ->
+    atomPackages =
+      'test-module':
+        metadata:
+          name: 'test-module'
+          version: '1.0.0'
+      'test2-module':
+        metadata:
+          name: 'test2-module'
+          version: '1.0.0'
+
+    fs.writeFileSync(path.join(resourcePath, 'package.json'), JSON.stringify(_atomPackages: atomPackages))
+
     packagesPath = path.join(atomHome, 'packages')
     fs.makeTreeSync(packagesPath)
     wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'test-module'), path.join(packagesPath, 'test-module'))
@@ -97,7 +109,10 @@ describe 'apm list', ->
       core: disabledPackages: ["test-module"]
 
     listPackages ['--enabled'], ->
-      expect(console.log.argsForCall[1][0]).toContain '(empty)'
+      expect(console.log.argsForCall[1][0]).toContain 'test2-module@1.0.0'
+      expect(console.log.argsForCall[3][0]).toContain 'dev-package@1.0.0'
+      expect(console.log.argsForCall[6][0]).toContain 'user-package@1.0.0'
+      expect(console.log.argsForCall[9][0]).toContain 'git-package@1.0.0'
 
   it 'lists packages in json format when --json is passed', ->
     listPackages ['--json'], ->

--- a/spec/list-spec.coffee
+++ b/spec/list-spec.coffee
@@ -88,6 +88,17 @@ describe 'apm list', ->
     listPackages [], ->
       expect(console.log.argsForCall[1][0]).toContain 'test-module@1.0.0 (disabled)'
 
+  it 'displays only enabled packages --enabled is called', ->
+    packagesPath = path.join(atomHome, 'packages')
+    fs.makeTreeSync(packagesPath)
+    wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'test-module'), path.join(packagesPath, 'test-module'))
+    configPath = path.join(atomHome, 'config.cson')
+    CSON.writeFileSync configPath, '*':
+      core: disabledPackages: ["test-module"]
+
+    listPackages ['--enabled'], ->
+      expect(console.log.argsForCall[1][0]).toContain '(empty)'
+
   it 'lists packages in json format when --json is passed', ->
     listPackages ['--json'], ->
       json = JSON.parse(console.log.argsForCall[0][0])

--- a/src/list.coffee
+++ b/src/list.coffee
@@ -119,18 +119,20 @@ class List extends Command
     callback?(null, gitPackages)
 
   listBundledPackages: (options, callback) ->
-    config.getResourcePath (resourcePath) ->
+    config.getResourcePath (resourcePath) =>
       try
         metadataPath = path.join(resourcePath, 'package.json')
         {_atomPackages} = JSON.parse(fs.readFileSync(metadataPath))
       _atomPackages ?= {}
       packages = (metadata for packageName, {metadata} of _atomPackages)
 
-      packages = packages.filter (metadata) ->
+      packages = packages.filter (metadata) =>
         if options.argv.themes
           metadata.theme
         else if options.argv.packages
           not metadata.theme
+        else if options.argv.enabled
+          not @isPackageDisabled(metadata.name)
         else
           true
 

--- a/src/list.coffee
+++ b/src/list.coffee
@@ -30,12 +30,14 @@ class List extends Command
              apm list --themes
              apm list --packages
              apm list --installed
+             apm list --installed --enabled
              apm list --installed --bare > my-packages.txt
              apm list --json
 
       List all the installed packages and also the packages bundled with Atom.
     """
     options.alias('b', 'bare').boolean('bare').describe('bare', 'Print packages one per line with no formatting')
+    options.alias('e', 'enabled').boolean('enabled').describe('enabled', 'Print only enabled packages')
     options.alias('d', 'dev').boolean('dev').default('dev', true).describe('dev', 'Include dev packages')
     options.alias('h', 'help').describe('help', 'Print this usage message')
     options.alias('i', 'installed').boolean('installed').describe('installed', 'Only list installed packages/themes')
@@ -81,11 +83,11 @@ class List extends Command
       manifest ?= {}
       manifest.name = child
       if options.argv.themes
-        packages.push(manifest) if manifest.theme
+        packages.push(manifest) if manifest.theme and not (options.argv.enabled and @isPackageDisabled(child))
       else if options.argv.packages
-        packages.push(manifest) unless manifest.theme
+        packages.push(manifest) unless manifest.theme or (options.argv.enabled and @isPackageDisabled(child))
       else
-        packages.push(manifest)
+        packages.push(manifest) unless options.argv.enabled and @isPackageDisabled(child)
 
     packages
 

--- a/src/list.coffee
+++ b/src/list.coffee
@@ -83,11 +83,14 @@ class List extends Command
       manifest ?= {}
       manifest.name = child
       if options.argv.themes
-        packages.push(manifest) if manifest.theme and not (options.argv.enabled and @isPackageDisabled(child))
+        if manifest.theme and not (options.argv.enabled and @isPackageDisabled(manifest.name))
+          packages.push(manifest)
       else if options.argv.packages
-        packages.push(manifest) unless manifest.theme or (options.argv.enabled and @isPackageDisabled(child))
+        unless manifest.theme or (options.argv.enabled and @isPackageDisabled(manifest.name))
+          packages.push(manifest)
       else
-        packages.push(manifest) unless options.argv.enabled and @isPackageDisabled(child)
+        unless options.argv.enabled and @isPackageDisabled(manifest.name)
+          packages.push(manifest)
 
     packages
 

--- a/src/package-converter.coffee
+++ b/src/package-converter.coffee
@@ -165,8 +165,7 @@ class PackageConverter
       try
         selector = new ScopeSelector(scope).toCssSelector() if scope
       catch e
-        e.fileName = path.join(sourceSnippets, child)
-        e.message = "In file " + e.fileName + " at " + JSON.stringify(scope) + ": " + e.message
+        e.message = "In file #{e.fileName} at #{JSON.stringify(scope)}: #{e.message}"
         throw e
       selector ?= '*'
 

--- a/src/package-converter.coffee
+++ b/src/package-converter.coffee
@@ -191,8 +191,7 @@ class PackageConverter
         try
           selector = new ScopeSelector(scope).toCssSelector()
         catch e
-          e.fileName = path.join(sourcePreferences, child)
-          e.message = "In file " + e.fileName + " at " + JSON.stringify(scope) + ": " + e.message
+          e.message = "In file #{e.fileName} at #{JSON.stringify(scope)}: #{e.message}"
           throw e
         for key, value of properties
           preferencesBySelector[selector] ?= {}

--- a/src/package-converter.coffee
+++ b/src/package-converter.coffee
@@ -162,7 +162,12 @@ class PackageConverter
         extension = path.extname(child)
         name = path.basename(child, extension)
 
-      selector = new ScopeSelector(scope).toCssSelector() if scope
+      try
+        selector = new ScopeSelector(scope).toCssSelector() if scope
+      catch e
+        e.fileName = path.join(sourceSnippets, child)
+        e.message = "In file " + e.fileName + " at " + JSON.stringify(scope) + ": " + e.message
+        throw e
       selector ?= '*'
 
       snippetsBySelector[selector] ?= {}
@@ -184,7 +189,12 @@ class PackageConverter
       continue unless scope and settings
 
       if properties = @convertSettings(settings)
-        selector = new ScopeSelector(scope).toCssSelector()
+        try
+          selector = new ScopeSelector(scope).toCssSelector()
+        catch e
+          e.fileName = path.join(sourcePreferences, child)
+          e.message = "In file " + e.fileName + " at " + JSON.stringify(scope) + ": " + e.message
+          throw e
         for key, value of properties
           preferencesBySelector[selector] ?= {}
           if preferencesBySelector[selector][key]?


### PR DESCRIPTION
### Description of the Change
#### Change 1: Textmate Bundle Conversion Error Reporting
My change is in response to atom/first-mate#51 – an issue which requested that Atom Package Manager give more information, such as file names and line numbers, in regards to errors when converting TextMate Bundle files to an Atom digestible format. 

I decided to apply the fix in apm instead of first-mate since the information required to locate the source of the error is not made available to first-mate. Additionally, it appears to be near impossible (or at least efficient) to ascertain an exact location of an error, so I elected to output the malformed piece of text instead, which should hopefully give enough information to the user to debug their program.

#### Change 2: New `apm list` command
Due to a mistake on my part, instead of opening a new pull request for this change, I accidentally merged it into this pull request. The second change is one that fulfills #732 – an issue that requests a feature that allowed for the command `apm list --installed --enabled` to list enabled packages in Atom.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
My first thought was to feed the _scope_ variable (that had a chance to be malformed, causing the crash), back into a regex on the original file, allowing the error position to be ascertained. However, given how the Package Converter is structured, it would be too computationally intensive to perform such an action.

No alternate design was considered for the second change. I do not see any method as simple and concise as the approach I took

### Benefits

<!-- What benefits will be realized by the code change? -->
Better error reporting during TextMate Bundle conversion.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
I see no possible drawbacks to this change.

### Applicable Issues

<!-- Enter any applicable Issues here -->
atom/first-mate#51