### PR TITLE
Depend on node-gyp explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mv": "2.0.0",
     "ncp": "~0.5.1",
     "npm": "3.10.10",
+    "node-gyp": "3.4.0",
     "open": "0.0.4",
     "plist": "git+https://github.com/nathansobo/node-plist.git",
     "q": "~0.9.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom-package-manager",
   "description": "Atom package manager",
-  "version": "1.18.2",
+  "version": "1.18.3-0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We're matching the same version that the bundled npm depends on. This will help us ensure that regardless of how npm organizes the directories, we will know how to access the node-gyp binary. The risk is that someone will update npm without updating node-gyp.