### PR TITLE
Always fall back to ATOM_ACCESS_TOKEN when there is no token

### DIFF
--- a/src/auth.coffee
+++ b/src/auth.coffee
@@ -4,8 +4,8 @@ catch error
   # Gracefully handle keytar failing to load due to missing library on Linux
   if process.platform is 'linux'
     keytar =
-      findPassword: ->
-      replacePassword: ->
+      findPassword: -> Promise.reject()
+      setPassword: -> Promise.reject()
   else
     throw error
 
@@ -17,19 +17,20 @@ module.exports =
   # callback - A function to call with an error as the first argument and a
   #            string token as the second argument.
   getToken: (callback) ->
-    keytar.findPassword(tokenName).then (token) ->
-      if token
-        callback(null, token)
-        return
-
-      if token = process.env.ATOM_ACCESS_TOKEN
-        callback(null, token)
-        return
-
-      callback """
-        No Atom.io API token in keychain
-        Run `apm login` or set the `ATOM_ACCESS_TOKEN` environment variable.
-      """
+    keytar.findPassword(tokenName)
+      .then (token) ->
+        if token
+          callback(null, token)
+        else
+          Promise.reject()
+      .catch ->
+        if token = process.env.ATOM_ACCESS_TOKEN
+          callback(null, token)
+        else
+          callback """
+            No Atom.io API token in keychain
+            Run `apm login` or set the `ATOM_ACCESS_TOKEN` environment variable.
+          """
 
   # Save the given token to the keychain.
   #


### PR DESCRIPTION
### Description of the Change

This fixes two issues related to `keytar`'s recent switch to a Promise-based API (see atom/node-keytar#63). 

### Benefits

* If `keytar.findPassword`'s promise was rejected, there was an uncaught promise rejection exception, instead of falling back to `process.env.ATOM_ACCESS_TOKEN`. That's fixed.
* If `keytar` failed to load, the stub for `findPassword` would return `undefined` instead of a promise. That's fixed.
* The `keytar` stub module had a `replacePassword` method, when it should in fact be `setPassword`. That's fixed.

### Possible Drawbacks

None.

### Applicable Issues

Nuclide publishes from CircleCI, which is where this issue was found. See `./scripts/oss-publish.sh` in https://circleci.com/gh/facebook/nuclide/1537

```
(node:18872) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Address element '/dev/null' does not contain a colon (:)
```
