### PR TITLE
Revert "Stop using asar archives"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom-package-manager",
   "description": "Atom package manager",
-  "version": "1.18.3",
+  "version": "1.18.4-0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -26,24 +26,28 @@ module.exports =
 
     apmFolder = path.resolve(__dirname, '..')
     appFolder = path.dirname(apmFolder)
-    if path.basename(apmFolder) is 'apm' and path.basename(appFolder) is 'app' and fs.existsSync(appFolder)
-      return process.nextTick -> callback(appFolder)
+    if path.basename(apmFolder) is 'apm' and path.basename(appFolder) is 'app'
+      asarPath = "#{appFolder}.asar"
+      if fs.existsSync(asarPath)
+        return process.nextTick -> callback(asarPath)
 
     apmFolder = path.resolve(__dirname, '..', '..', '..')
     appFolder = path.dirname(apmFolder)
-    if path.basename(apmFolder) is 'apm' and path.basename(appFolder) is 'app' and fs.existsSync(appFolder)
-      return process.nextTick -> callback(appFolder)
+    if path.basename(apmFolder) is 'apm' and path.basename(appFolder) is 'app'
+      asarPath = "#{appFolder}.asar"
+      if fs.existsSync(asarPath)
+        return process.nextTick -> callback(asarPath)
 
     switch process.platform
       when 'darwin'
         child_process.exec 'mdfind "kMDItemCFBundleIdentifier == \'com.github.atom\'"', (error, stdout='', stderr) ->
           [appLocation] = stdout.split('\n') unless error
           appLocation = '/Applications/Atom.app' unless appLocation
-          callback("#{appLocation}/Contents/Resources/app")
+          callback("#{appLocation}/Contents/Resources/app.asar")
       when 'linux'
-        appLocation = '/usr/local/share/atom/resources/app'
+        appLocation = '/usr/local/share/atom/resources/app.asar'
         unless fs.existsSync(appLocation)
-          appLocation = '/usr/share/atom/resources/app'
+          appLocation = '/usr/share/atom/resources/app.asar'
         process.nextTick -> callback(appLocation)
 
   getReposDirectory: ->


### PR DESCRIPTION
Reverts atom/apm#693, since we turned .asar archives back on as part of https://github.com/atom/atom/pull/14682.

@nathansobo: I believe this will fix the `Could not determine Electron version` error we were observing when running `apm install`.

/cc: @iolsen 