### PR TITLE
Add Atom version to the printed version information

### DIFF
--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -106,7 +106,7 @@ printVersions = (args, callback) ->
             apm: apmVersion
             npm: npmVersion
             node: nodeVersion
-            atomVersion: atomVersion
+            atom: atomVersion
             python: pythonVersion
             git: gitVersion
             nodeArch: process.arch

--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -136,9 +136,6 @@ printVersions = (args, callback) ->
 getAtomVersion = (callback) ->
   config.getResourcePath (resourcePath) ->
     unknownVersion = 'unknown'
-    # workaround if app.asar does not exist. see: https://github.com/atom/atom/issues/6604
-    if not fs.existsSync(resourcePath)
-      resourcePath = resourcePath.replace('.asar', path.sep)
     try
       {version} = require(path.join(resourcePath, 'package.json')) ? unknownVersion
       callback(version)

--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -100,34 +100,50 @@ printVersions = (args, callback) ->
 
   getPythonVersion (pythonVersion) ->
     git.getGitVersion (gitVersion) ->
-      if args.json
-        versions =
-          apm: apmVersion
-          npm: npmVersion
-          node: nodeVersion
-          python: pythonVersion
-          git: gitVersion
-          nodeArch: process.arch
-        if config.isWin32()
-          versions.visualStudio = config.getInstalledVisualStudioFlag()
-        console.log JSON.stringify(versions)
-      else
-        pythonVersion ?= ''
-        gitVersion ?= ''
-        versions =  """
-          #{'apm'.red}  #{apmVersion.red}
-          #{'npm'.green}  #{npmVersion.green}
-          #{'node'.blue} #{nodeVersion.blue} #{process.arch.blue}
-          #{'python'.yellow} #{pythonVersion.yellow}
-          #{'git'.magenta} #{gitVersion.magenta}
-        """
+      getAtomVersion (atomVersion) ->
+        if args.json
+          versions =
+            apm: apmVersion
+            npm: npmVersion
+            node: nodeVersion
+            atomVersion: atomVersion
+            python: pythonVersion
+            git: gitVersion
+            nodeArch: process.arch
+          if config.isWin32()
+            versions.visualStudio = config.getInstalledVisualStudioFlag()
+          console.log JSON.stringify(versions)
+        else
+          pythonVersion ?= ''
+          gitVersion ?= ''
+          atomVersion ?= ''
+          versions =  """
+            #{'apm'.red}  #{apmVersion.red}
+            #{'npm'.green}  #{npmVersion.green}
+            #{'node'.blue} #{nodeVersion.blue} #{process.arch.blue}
+            #{'atom'.cyan} #{atomVersion.cyan}
+            #{'python'.yellow} #{pythonVersion.yellow}
+            #{'git'.magenta} #{gitVersion.magenta}
+          """
 
-        if config.isWin32()
-          visualStudioVersion = config.getInstalledVisualStudioFlag() ? ''
-          versions += "\n#{'visual studio'.cyan} #{visualStudioVersion.cyan}"
+          if config.isWin32()
+            visualStudioVersion = config.getInstalledVisualStudioFlag() ? ''
+            versions += "\n#{'visual studio'.cyan} #{visualStudioVersion.cyan}"
 
-        console.log versions
-      callback()
+          console.log versions
+        callback()
+
+getAtomVersion = (callback) ->
+  config.getResourcePath (resourcePath) ->
+    unknownVersion = 'unknown'
+    # workaround if app.asar does not exist. see: https://github.com/atom/atom/issues/6604
+    if not fs.existsSync(resourcePath)
+      resourcePath = resourcePath.replace('.asar', path.sep)
+    try
+      {version} = require(path.join(resourcePath, 'package.json')) ? unknownVersion
+      callback(version)
+    catch error
+      callback(unknownVersion)
 
 getPythonVersion = (callback) ->
   npmOptions =


### PR DESCRIPTION
![screen shot 2017-09-13 at 2 42 17 pm](https://user-images.githubusercontent.com/4303638/30395464-442591d0-9894-11e7-8970-b6c045a67024.png)

### Alternate Designs

Using `spawn` in `getPythonVersion`, similar to @arabelle's approach. See: https://github.com/arabelle/apm/blob/59f70d50571090fe205bf6b03c03f0c86398f5f4/src/apm-cli.coffee#L132-L143

I did not want to spawn a new process and parse it's output since I have access to Atom's  `package.json`

### Benefits

Closes #382

### Possible Drawbacks

There is [a workaround](https://github.com/virtuoushub/apm/blob/2322ed592e6e75c83200f09a2c62cd4e4d1e4df1/src/apm-cli.coffee#L138-L140) due to [an issue](https://github.com/atom/atom/issues/6604) on macOS I ran into while testing. Ideally, the workaround that checks with [`getResourcePath`](https://github.com/atom/apm/blob/a6285bc4e90e442906bc86542f885f79e2dea15e/src/apm.coffee#L23-L51) is not used.

### Applicable Issues

#453, #473, and [atom/atom#6604](https://github.com/atom/atom/issues/6604)

/cc @jebschiefer and @arabelle who worked on original PRs
