### PR TITLE
Use $binDir instead of $scriptDir to find python interceptor script

### DIFF
--- a/bin/apm
+++ b/bin/apm
@@ -50,7 +50,7 @@ do
   unset ${var%%=*}
 done
 
-export npm_config_python="${scriptDir}/python-interceptor.sh"
+export npm_config_python="${binDir}/python-interceptor.sh"
 
 cliPath="$binDir/../lib/cli.js"
 if [[ $(uname -r) == *-Microsoft ]]; then


### PR DESCRIPTION
Fix this error, encountered when installing a package with native dependencies from an installed `apm` script:

```
Error: Can't find Python executable "/usr/local/bin/python-interceptor.sh", you can set the PYTHON env variable.
```

/cc @maxbrunsfeld 