### PR TITLE
Display Atom version when 'apm --version' is called

### DIFF
--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -129,6 +129,19 @@ printVersions = (args, callback) ->
         console.log versions
       callback()
 
+getAtomVersion = (callback) ->
+  atom = 'atom'
+  spawned = 'spawned'
+  outputChunks = []
+  spawned.stderr.on 'data', (chunk) -> outputChunks.push(chunk)
+  spawned.stdout.on 'data', (chunk) -> outputChunks.push(chunk)
+  spawned.on 'error', ->
+  spawned.on 'close', (code) ->
+   if code is 0
+     version = Buffer.concat(outputChunks).toString()
+     version = version?.trim()
+   callback(version)
+
 getPythonVersion = (callback) ->
   npmOptions =
     userconfig: config.getUserConfigPath()


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Hey everyone, this is my first contribution to the Atom Suite and I'm so excited! This PR fixes #382. From now on when you type `apm --version` the atom version is going to be presented. Please let me know if I can improve the approach of mine regarding this issue or we're good to go with this one.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->