### PR TITLE
Don't unpack array

### DIFF
--- a/src/disable.coffee
+++ b/src/disable.coffee
@@ -69,7 +69,7 @@ class Disable extends Command
 
       keyPath = '*.core.disabledPackages'
       disabledPackages = _.valueForKeyPath(settings, keyPath) ? []
-      result = _.union(disabledPackages, packageNames...)
+      result = _.union(disabledPackages, packageNames)
       _.setValueForKeyPath(settings, keyPath, result)
 
       try


### PR DESCRIPTION
### Description of the Change

Doesn't unpack array of package names when calling [`_.union`](https://underscorejs.org/#union), so it works properly. The original version only worked because of a bug in underscore.js, which was patched some time between version 1.6.0 and 1.8.3 (of _.js). They have now explicitly prevented non-arrays from appearing in the output of a union. I.e., `_.union([1, 2], 3, [4]) === [1, 2, 4]` (and that 3 was the disabled package...)

### Benefits

Actually disable packages

### Possible Drawbacks

I don't know why the spread was there initially. I compiled and tested though, and disabling worked fine.

### Applicable Issues

Fix #801 
Fix atom/atom#17741