### PR TITLE
Upgrade npm to 6.2.0 to fix Windows long file path issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.0.tgz",
       "integrity": "sha1-6yhAdG6dxIvV4GOjbj/UAMXqtak=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "amdefine": {
@@ -47,8 +47,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -61,13 +61,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -75,7 +75,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -86,7 +86,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "array-find-index": {
@@ -100,8 +100,8 @@
       "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
       "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
       "requires": {
-        "debug": "^2.2.0",
-        "es6-symbol": "^3.0.2"
+        "debug": "2.6.9",
+        "es6-symbol": "3.1.1"
       },
       "dependencies": {
         "d": {
@@ -109,7 +109,7 @@
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "requires": {
-            "es5-ext": "^0.10.9"
+            "es5-ext": "0.10.37"
           }
         },
         "es6-symbol": {
@@ -117,8 +117,8 @@
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
           "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
           "requires": {
-            "d": "1",
-            "es5-ext": "~0.10.14"
+            "d": "1.0.0",
+            "es5-ext": "0.10.37"
           }
         }
       }
@@ -128,13 +128,13 @@
       "resolved": "https://registry.npmjs.org/asar/-/asar-0.12.1.tgz",
       "integrity": "sha1-35Q+jrXNdPvKBmPi10uPK3J7UI8=",
       "requires": {
-        "chromium-pickle-js": "^0.1.0",
-        "commander": "^2.9.0",
-        "cuint": "^0.2.1",
-        "glob": "^6.0.4",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "mksnapshot": "^0.3.0",
+        "chromium-pickle-js": "0.1.0",
+        "commander": "2.12.2",
+        "cuint": "0.2.2",
+        "glob": "6.0.4",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "mksnapshot": "0.3.1",
         "tmp": "0.0.28"
       }
     },
@@ -187,7 +187,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "binary": {
@@ -195,8 +195,8 @@
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "requires": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
+        "buffers": "0.1.1",
+        "chainsaw": "0.1.0"
       }
     },
     "block-stream": {
@@ -204,7 +204,7 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
-        "inherits": "~2.0.0"
+        "inherits": "2.0.3"
       }
     },
     "boom": {
@@ -212,7 +212,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.0"
       }
     },
     "brace-expansion": {
@@ -220,7 +220,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -258,8 +258,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       }
     },
     "caseless": {
@@ -272,7 +272,7 @@
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "requires": {
-        "traverse": ">=0.3.0 <0.4"
+        "traverse": "0.3.9"
       }
     },
     "chalk": {
@@ -281,11 +281,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "chromium-pickle-js": {
@@ -298,9 +298,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       }
     },
     "co": {
@@ -324,12 +324,12 @@
       "integrity": "sha1-g9jtHa/eOmd95E57ihi+YHdh5tg=",
       "dev": true,
       "requires": {
-        "coffee-script": "~1.11.0",
-        "glob": "^7.0.6",
-        "ignore": "^3.0.9",
-        "optimist": "^0.6.1",
-        "resolve": "^0.6.3",
-        "strip-json-comments": "^1.0.2"
+        "coffee-script": "1.11.1",
+        "glob": "7.1.2",
+        "ignore": "3.3.7",
+        "optimist": "0.6.1",
+        "resolve": "0.6.3",
+        "strip-json-comments": "1.0.4"
       },
       "dependencies": {
         "coffee-script": {
@@ -344,12 +344,12 @@
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "optimist": {
@@ -358,8 +358,8 @@
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.2"
           }
         },
         "resolve": {
@@ -376,8 +376,8 @@
       "integrity": "sha1-q1AaZENeIxcG2hOidSeraVcAq8k=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "text-table": "^0.2.0"
+        "chalk": "1.1.3",
+        "text-table": "0.2.0"
       }
     },
     "coffeestack": {
@@ -386,9 +386,9 @@
       "integrity": "sha1-NSePO+uc5vXQraH7bgh4UrZXzpg=",
       "dev": true,
       "requires": {
-        "coffee-script": "~1.8.0",
-        "fs-plus": "^2.5.0",
-        "source-map": "~0.1.43"
+        "coffee-script": "1.8.0",
+        "fs-plus": "2.10.1",
+        "source-map": "0.1.43"
       },
       "dependencies": {
         "coffee-script": {
@@ -397,7 +397,7 @@
           "integrity": "sha1-nJ8dK0pSoADe0Vtll5FwNkgmPB0=",
           "dev": true,
           "requires": {
-            "mkdirp": "~0.3.5"
+            "mkdirp": "0.3.5"
           }
         },
         "mkdirp": {
@@ -418,7 +418,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -441,7 +441,7 @@
         "bytes": "0.2.0",
         "cookie": "0.0.5",
         "cookie-signature": "1.0.1",
-        "debug": "*",
+        "debug": "2.6.9",
         "formidable": "1.0.14",
         "fresh": "0.1.0",
         "pause": "0.0.1",
@@ -467,9 +467,9 @@
           "integrity": "sha1-C8/L0D3vbi2GEuGr+PSJW0UMYMg=",
           "dev": true,
           "requires": {
-            "debug": "*",
+            "debug": "2.6.9",
             "fresh": "0.1.0",
-            "mime": "~1.2.9",
+            "mime": "1.2.11",
             "range-parser": "0.0.4"
           }
         }
@@ -502,7 +502,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -510,7 +510,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.0"
           }
         }
       }
@@ -534,7 +534,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "d": {
@@ -542,7 +542,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
       "requires": {
-        "es5-ext": "~0.10.2"
+        "es5-ext": "0.10.37"
       }
     },
     "dashdash": {
@@ -550,7 +550,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "dateformat": {
@@ -559,8 +559,8 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1",
-        "meow": "^3.3.0"
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
       }
     },
     "debug": {
@@ -581,12 +581,12 @@
       "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
       "integrity": "sha1-rjvLfjTGWHmt/nfhnDD4ZgK0vbA=",
       "requires": {
-        "binary": "^0.3.0",
-        "graceful-fs": "^4.1.3",
-        "mkpath": "^0.1.0",
-        "nopt": "^3.0.1",
-        "q": "^1.1.2",
-        "readable-stream": "^1.1.8",
+        "binary": "0.3.0",
+        "graceful-fs": "4.1.11",
+        "mkpath": "0.1.0",
+        "nopt": "3.0.6",
+        "q": "1.5.1",
+        "readable-stream": "1.1.14",
         "touch": "0.0.3"
       },
       "dependencies": {
@@ -613,7 +613,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "emissary": {
@@ -621,10 +621,10 @@
       "resolved": "https://registry.npmjs.org/emissary/-/emissary-1.3.3.tgz",
       "integrity": "sha1-phjZLWgrIy0xER3DYlpd9mF5lgY=",
       "requires": {
-        "es6-weak-map": "^0.1.2",
-        "mixto": "1.x",
-        "property-accessors": "^1.1",
-        "underscore-plus": "1.x"
+        "es6-weak-map": "0.1.4",
+        "mixto": "1.0.0",
+        "property-accessors": "1.1.3",
+        "underscore-plus": "1.6.6"
       }
     },
     "error-ex": {
@@ -633,7 +633,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es5-ext": {
@@ -641,8 +641,8 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
       "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "requires": {
-        "es6-iterator": "~2.0.1",
-        "es6-symbol": "~3.1.1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       },
       "dependencies": {
         "d": {
@@ -650,7 +650,7 @@
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "requires": {
-            "es5-ext": "^0.10.9"
+            "es5-ext": "0.10.37"
           }
         },
         "es6-iterator": {
@@ -658,9 +658,9 @@
           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
           "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
           "requires": {
-            "d": "1",
-            "es5-ext": "^0.10.35",
-            "es6-symbol": "^3.1.1"
+            "d": "1.0.0",
+            "es5-ext": "0.10.37",
+            "es6-symbol": "3.1.1"
           }
         },
         "es6-symbol": {
@@ -668,8 +668,8 @@
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
           "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
           "requires": {
-            "d": "1",
-            "es5-ext": "~0.10.14"
+            "d": "1.0.0",
+            "es5-ext": "0.10.37"
           }
         }
       }
@@ -679,9 +679,9 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
       "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
       "requires": {
-        "d": "~0.1.1",
-        "es5-ext": "~0.10.5",
-        "es6-symbol": "~2.0.1"
+        "d": "0.1.1",
+        "es5-ext": "0.10.37",
+        "es6-symbol": "2.0.1"
       }
     },
     "es6-symbol": {
@@ -689,8 +689,8 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
       "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
       "requires": {
-        "d": "~0.1.1",
-        "es5-ext": "~0.10.5"
+        "d": "0.1.1",
+        "es5-ext": "0.10.37"
       }
     },
     "es6-weak-map": {
@@ -698,10 +698,10 @@
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
       "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
       "requires": {
-        "d": "~0.1.1",
-        "es5-ext": "~0.10.6",
-        "es6-iterator": "~0.1.3",
-        "es6-symbol": "~2.0.1"
+        "d": "0.1.1",
+        "es5-ext": "0.10.37",
+        "es6-iterator": "0.1.3",
+        "es6-symbol": "2.0.1"
       }
     },
     "escape-string-regexp": {
@@ -721,7 +721,7 @@
       "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-1.5.0.tgz",
       "integrity": "sha1-Ek72qtgyjcsmtxxHWQtbjmPrxIc=",
       "requires": {
-        "grim": "^1.2.1"
+        "grim": "1.5.0"
       }
     },
     "eventemitter2": {
@@ -747,7 +747,7 @@
         "connect": "2.7.11",
         "cookie": "0.1.0",
         "cookie-signature": "1.0.1",
-        "debug": "*",
+        "debug": "2.6.9",
         "fresh": "0.1.0",
         "methods": "0.0.1",
         "mkdirp": "0.3.4",
@@ -795,8 +795,8 @@
       "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
       "dev": true,
       "requires": {
-        "glob": "3.x",
-        "minimatch": "0.x"
+        "glob": "3.2.11",
+        "minimatch": "0.4.0"
       },
       "dependencies": {
         "glob": {
@@ -805,8 +805,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2",
-            "minimatch": "0.3"
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
           },
           "dependencies": {
             "minimatch": {
@@ -815,8 +815,8 @@
               "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
               "dev": true,
               "requires": {
-                "lru-cache": "2",
-                "sigmund": "~1.0.0"
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
               }
             }
           }
@@ -827,8 +827,8 @@
           "integrity": "sha1-vSx9Bg0sjI/Xzefx8u0tWycP2xs=",
           "dev": true,
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         }
       }
@@ -839,8 +839,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "findup-sync": {
@@ -849,7 +849,7 @@
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
       "requires": {
-        "glob": "~5.0.0"
+        "glob": "5.0.15"
       },
       "dependencies": {
         "glob": {
@@ -858,11 +858,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -872,13 +872,13 @@
       "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-6.2.0.tgz",
       "integrity": "sha1-lSnK5evqVkC03DxD7ViMWzUoVa8=",
       "requires": {
-        "emissary": "^1",
-        "event-kit": "^1.0.0",
-        "fs-plus": "^2",
-        "grim": "^1.2.1",
-        "oniguruma": "^6.1.0",
-        "season": "^5.0.2",
-        "underscore-plus": "^1"
+        "emissary": "1.3.3",
+        "event-kit": "1.5.0",
+        "fs-plus": "2.10.1",
+        "grim": "1.5.0",
+        "oniguruma": "6.2.1",
+        "season": "5.4.1",
+        "underscore-plus": "1.6.6"
       },
       "dependencies": {
         "season": {
@@ -887,8 +887,8 @@
           "integrity": "sha1-S9baYVKn8tbwixQzzi2SBmmFPQ0=",
           "requires": {
             "cson-parser": "1.0.9",
-            "fs-plus": "2.x",
-            "optimist": "~0.4.0"
+            "fs-plus": "2.10.1",
+            "optimist": "0.4.0"
           }
         }
       }
@@ -903,9 +903,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.5",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
       }
     },
     "formidable": {
@@ -925,11 +925,11 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
       "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.6.2"
       }
     },
     "fs-plus": {
@@ -937,10 +937,10 @@
       "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-2.10.1.tgz",
       "integrity": "sha1-MgR4HXhAYR5jZOe2+wWMljJ8WqU=",
       "requires": {
-        "async": "^1.5.2",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.2",
-        "underscore-plus": "1.x"
+        "async": "1.5.2",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "underscore-plus": "1.6.6"
       },
       "dependencies": {
         "async": {
@@ -960,10 +960,10 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
       }
     },
     "gauge": {
@@ -971,15 +971,15 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
       "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-color": "^0.1.7",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-color": "0.1.7",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
       }
     },
     "gaze": {
@@ -988,8 +988,8 @@
       "integrity": "sha1-X5S92gr+U7xxCWm81vKCVI1gwnk=",
       "dev": true,
       "requires": {
-        "fileset": "~0.1.5",
-        "minimatch": "~0.2.9"
+        "fileset": "0.1.8",
+        "minimatch": "0.2.14"
       },
       "dependencies": {
         "minimatch": {
@@ -998,8 +998,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         }
       }
@@ -1021,7 +1021,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "git-utils": {
@@ -1029,8 +1029,8 @@
       "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-4.1.4.tgz",
       "integrity": "sha1-uS0x9h/LTHNvSngxTeNuQbn8fWg=",
       "requires": {
-        "fs-plus": "^2.1.0",
-        "nan": "^2.0.0"
+        "fs-plus": "2.10.1",
+        "nan": "2.8.0"
       }
     },
     "glob": {
@@ -1038,11 +1038,11 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
       "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
       "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -1055,7 +1055,7 @@
       "resolved": "https://registry.npmjs.org/grim/-/grim-1.5.0.tgz",
       "integrity": "sha1-sysI71Z88YUvgXWe2caLDXE5ajI=",
       "requires": {
-        "emissary": "^1.2.0"
+        "emissary": "1.3.3"
       }
     },
     "grunt": {
@@ -1064,22 +1064,22 @@
       "integrity": "sha1-6HeHZOlEsY8yuw8QuQeEdcnftWs=",
       "dev": true,
       "requires": {
-        "coffee-script": "~1.10.0",
-        "dateformat": "~1.0.12",
-        "eventemitter2": "~0.4.13",
-        "exit": "~0.1.1",
-        "findup-sync": "~0.3.0",
-        "glob": "~7.0.0",
-        "grunt-cli": "~1.2.0",
-        "grunt-known-options": "~1.1.0",
-        "grunt-legacy-log": "~1.0.0",
-        "grunt-legacy-util": "~1.0.0",
-        "iconv-lite": "~0.4.13",
-        "js-yaml": "~3.5.2",
-        "minimatch": "~3.0.0",
-        "nopt": "~3.0.6",
-        "path-is-absolute": "~1.0.0",
-        "rimraf": "~2.2.8"
+        "coffee-script": "1.10.0",
+        "dateformat": "1.0.12",
+        "eventemitter2": "0.4.14",
+        "exit": "0.1.2",
+        "findup-sync": "0.3.0",
+        "glob": "7.0.6",
+        "grunt-cli": "1.2.0",
+        "grunt-known-options": "1.1.0",
+        "grunt-legacy-log": "1.0.0",
+        "grunt-legacy-util": "1.0.0",
+        "iconv-lite": "0.4.19",
+        "js-yaml": "3.5.5",
+        "minimatch": "3.0.4",
+        "nopt": "3.0.6",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "coffee-script": {
@@ -1094,12 +1094,12 @@
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "rimraf": {
@@ -1116,10 +1116,10 @@
       "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
       "dev": true,
       "requires": {
-        "findup-sync": "~0.3.0",
-        "grunt-known-options": "~1.1.0",
-        "nopt": "~3.0.6",
-        "resolve": "~1.1.0"
+        "findup-sync": "0.3.0",
+        "grunt-known-options": "1.1.0",
+        "nopt": "3.0.6",
+        "resolve": "1.1.7"
       }
     },
     "grunt-coffeelint": {
@@ -1128,8 +1128,8 @@
       "integrity": "sha1-0iPUIwWmuXdqtbehQuFFP4hmK5s=",
       "dev": true,
       "requires": {
-        "coffeelint": "^1",
-        "coffeelint-stylish": "~0.1.0"
+        "coffeelint": "1.16.0",
+        "coffeelint-stylish": "0.1.2"
       }
     },
     "grunt-contrib-coffee": {
@@ -1138,10 +1138,10 @@
       "integrity": "sha1-2u6wSVTxTihovMm6bq+RBf3C2kw=",
       "dev": true,
       "requires": {
-        "chalk": "~1.0.0",
-        "coffee-script": "~1.10.0",
-        "lodash": "~4.3.0",
-        "uri-path": "~1.0.0"
+        "chalk": "1.0.0",
+        "coffee-script": "1.10.0",
+        "lodash": "4.3.0",
+        "uri-path": "1.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1156,11 +1156,11 @@
           "integrity": "sha1-s89O0P9Tl8mcdbj2edsvUoMfltw=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.0.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^1.0.3",
-            "strip-ansi": "^2.0.1",
-            "supports-color": "^1.3.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "1.0.3",
+            "strip-ansi": "2.0.1",
+            "supports-color": "1.3.1"
           }
         },
         "coffee-script": {
@@ -1175,8 +1175,8 @@
           "integrity": "sha1-wLWxYV2eOCsP9nFp2We0JeSMpTg=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^1.1.0",
-            "get-stdin": "^4.0.1"
+            "ansi-regex": "1.1.1",
+            "get-stdin": "4.0.1"
           }
         },
         "lodash": {
@@ -1191,7 +1191,7 @@
           "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^1.0.0"
+            "ansi-regex": "1.1.1"
           }
         },
         "supports-color": {
@@ -1214,11 +1214,11 @@
       "integrity": "sha1-+4bxgJhHvAfcR4Q/ns1srLYt8tU=",
       "dev": true,
       "requires": {
-        "colors": "~1.1.2",
-        "grunt-legacy-log-utils": "~1.0.0",
-        "hooker": "~0.2.3",
-        "lodash": "~3.10.1",
-        "underscore.string": "~3.2.3"
+        "colors": "1.1.2",
+        "grunt-legacy-log-utils": "1.0.0",
+        "hooker": "0.2.3",
+        "lodash": "3.10.1",
+        "underscore.string": "3.2.3"
       },
       "dependencies": {
         "colors": {
@@ -1235,8 +1235,8 @@
       "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
       "dev": true,
       "requires": {
-        "chalk": "~1.1.1",
-        "lodash": "~4.3.0"
+        "chalk": "1.1.3",
+        "lodash": "4.3.0"
       },
       "dependencies": {
         "lodash": {
@@ -1253,13 +1253,13 @@
       "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
       "dev": true,
       "requires": {
-        "async": "~1.5.2",
-        "exit": "~0.1.1",
-        "getobject": "~0.1.0",
-        "hooker": "~0.2.3",
-        "lodash": "~4.3.0",
-        "underscore.string": "~3.2.3",
-        "which": "~1.2.1"
+        "async": "1.5.2",
+        "exit": "0.1.2",
+        "getobject": "0.1.0",
+        "hooker": "0.2.3",
+        "lodash": "4.3.0",
+        "underscore.string": "3.2.3",
+        "which": "1.2.14"
       },
       "dependencies": {
         "async": {
@@ -1280,7 +1280,7 @@
           "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         }
       }
@@ -1291,9 +1291,9 @@
       "integrity": "sha1-XivuzQXV03h/pAECjVcz1dQ7m9E=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "npm-run-path": "^1.0.0",
-        "object-assign": "^4.0.0"
+        "chalk": "1.1.3",
+        "npm-run-path": "1.0.0",
+        "object-assign": "4.1.1"
       }
     },
     "har-schema": {
@@ -1306,8 +1306,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.0",
+        "har-schema": "2.0.0"
       }
     },
     "has-ansi": {
@@ -1316,7 +1316,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-color": {
@@ -1334,10 +1334,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.1.0"
       }
     },
     "hoek": {
@@ -1361,9 +1361,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
       }
     },
     "iconv-lite": {
@@ -1384,7 +1384,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "inflight": {
@@ -1392,8 +1392,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -1418,7 +1418,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-finite": {
@@ -1427,7 +1427,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -1435,7 +1435,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-typedarray": {
@@ -1471,23 +1471,22 @@
       "dev": true,
       "requires": {
         "jasmine-node": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
-        "underscore-plus": "1.x",
+        "underscore-plus": "1.6.6",
         "walkdir": "0.0.7"
       }
     },
     "jasmine-node": {
       "version": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
-      "from": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
       "dev": true,
       "requires": {
-        "coffee-script": ">=1.0.1",
-        "coffeestack": ">=1 <2",
-        "gaze": "~0.3.2",
-        "jasmine-reporters": ">=0.2.0",
-        "mkdirp": "~0.3.5",
-        "requirejs": ">=0.27.1",
-        "underscore": ">= 1.3.1",
-        "walkdir": ">= 0.0.1"
+        "coffee-script": "1.9.0",
+        "coffeestack": "1.1.2",
+        "gaze": "0.3.4",
+        "jasmine-reporters": "2.2.1",
+        "mkdirp": "0.3.5",
+        "requirejs": "2.3.5",
+        "underscore": "1.6.0",
+        "walkdir": "0.0.7"
       },
       "dependencies": {
         "mkdirp": {
@@ -1504,8 +1503,8 @@
       "integrity": "sha1-3pqSATZ4RiaefKit/1tEIhZx/L0=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1",
-        "xmldom": "^0.1.22"
+        "mkdirp": "0.5.1",
+        "xmldom": "0.1.27"
       }
     },
     "js-yaml": {
@@ -1514,8 +1513,8 @@
       "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.2",
-        "esprima": "^2.6.0"
+        "argparse": "1.0.9",
+        "esprima": "2.7.3"
       }
     },
     "jsbn": {
@@ -1544,7 +1543,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsprim": {
@@ -1578,7 +1577,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.11"
       }
     },
     "lcid": {
@@ -1586,7 +1585,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "load-json-file": {
@@ -1595,11 +1594,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       }
     },
     "lodash": {
@@ -1614,8 +1613,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lru-cache": {
@@ -1636,16 +1635,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -1678,7 +1677,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "~1.30.0"
+        "mime-db": "1.30.0"
       }
     },
     "minimatch": {
@@ -1686,7 +1685,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
@@ -1719,7 +1718,7 @@
       "requires": {
         "decompress-zip": "0.3.0",
         "fs-extra": "0.26.7",
-        "request": "^2.79.0"
+        "request": "2.83.0"
       }
     },
     "ms": {
@@ -1737,9 +1736,9 @@
       "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.0.tgz",
       "integrity": "sha1-jn7CtRh8hHFNd8jpg7HtKdejOhs=",
       "requires": {
-        "mkdirp": "~0.3.5",
-        "ncp": "~0.4.2",
-        "rimraf": "~2.2.6"
+        "mkdirp": "0.3.5",
+        "ncp": "0.4.2",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "mkdirp": {
@@ -1774,20 +1773,20 @@
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
       "integrity": "sha1-3aVYOTs+y74kyea4cDxxGUxj+jY=",
       "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3",
-        "osenv": "0",
-        "path-array": "^1.0.0",
-        "request": "2",
-        "rimraf": "2",
-        "semver": "2.x || 3.x || 4 || 5",
-        "tar": "^2.0.0",
-        "which": "1"
+        "fstream": "1.0.11",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "npmlog": "3.1.2",
+        "osenv": "0.1.4",
+        "path-array": "1.0.1",
+        "request": "2.83.0",
+        "rimraf": "2.6.2",
+        "semver": "5.4.1",
+        "tar": "2.2.1",
+        "which": "1.3.0"
       },
       "dependencies": {
         "glob": {
@@ -1795,12 +1794,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -1810,7 +1809,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -1819,163 +1818,179 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.4.1",
+        "validate-npm-package-license": "3.0.1"
       }
     },
     "npm": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.1.0.tgz",
-      "integrity": "sha512-e38cCtJ0lEjLXXpc4twEfj8Xw5hDLolc2Py87ueWnUhJfZ8GA/5RVIeD+XbSr1+aVRGsRsdtLdzUNO63PvQJ1w==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.2.0.tgz",
+      "integrity": "sha512-GnlNsOnxwVJX4WSfyQY0gY3LnUX2cc46XU0eu1g+WSuZgDRUGmw8tuptitJu6byp0RWGT8ZEAKajblwdhQHN8A==",
       "requires": {
-        "JSONStream": "^1.3.2",
-        "abbrev": "~1.1.1",
-        "ansi-regex": "~3.0.0",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "aproba": "~1.2.0",
-        "archy": "~1.0.0",
-        "bin-links": "^1.1.2",
-        "bluebird": "~3.5.1",
-        "byte-size": "^4.0.3",
-        "cacache": "^11.0.2",
-        "call-limit": "~1.1.0",
-        "chownr": "~1.0.1",
-        "cli-columns": "^3.1.2",
-        "cli-table2": "~0.2.0",
-        "cmd-shim": "~2.0.2",
-        "columnify": "~1.5.4",
-        "config-chain": "~1.1.11",
-        "debuglog": "*",
-        "detect-indent": "~5.0.0",
-        "detect-newline": "^2.1.0",
-        "dezalgo": "~1.0.3",
-        "editor": "~1.0.0",
-        "figgy-pudding": "^3.1.0",
-        "find-npm-prefix": "^1.0.2",
-        "fs-vacuum": "~1.2.10",
-        "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.0.1",
-        "glob": "~7.1.2",
-        "graceful-fs": "~4.1.11",
-        "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.6.0",
-        "iferr": "^1.0.0",
-        "imurmurhash": "*",
-        "inflight": "~1.0.6",
-        "inherits": "~2.0.3",
-        "ini": "^1.3.5",
-        "init-package-json": "^1.10.3",
-        "is-cidr": "^2.0.5",
-        "json-parse-better-errors": "^1.0.2",
-        "lazy-property": "~1.0.0",
-        "libcipm": "^1.6.2",
-        "libnpmhook": "^4.0.1",
-        "libnpx": "^10.2.0",
-        "lock-verify": "^2.0.2",
-        "lockfile": "^1.0.4",
-        "lodash._baseindexof": "*",
-        "lodash._baseuniq": "~4.6.0",
-        "lodash._bindcallback": "*",
-        "lodash._cacheindexof": "*",
-        "lodash._createcache": "*",
-        "lodash._getnative": "*",
-        "lodash.clonedeep": "~4.5.0",
-        "lodash.restparam": "*",
-        "lodash.union": "~4.6.0",
-        "lodash.uniq": "~4.5.0",
-        "lodash.without": "~4.4.0",
-        "lru-cache": "^4.1.3",
-        "meant": "~1.0.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "~0.5.1",
-        "move-concurrently": "^1.0.1",
-        "node-gyp": "^3.6.2",
-        "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
-        "npm-audit-report": "^1.2.1",
-        "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^2.0.3",
-        "npm-package-arg": "^6.1.0",
-        "npm-packlist": "~1.1.10",
-        "npm-pick-manifest": "^2.1.0",
-        "npm-profile": "^3.0.1",
-        "npm-registry-client": "^8.5.1",
-        "npm-registry-fetch": "^1.1.0",
-        "npm-user-validate": "~1.0.0",
-        "npmlog": "~4.1.2",
-        "once": "~1.4.0",
-        "opener": "~1.4.3",
-        "osenv": "^0.1.5",
-        "pacote": "^8.1.5",
-        "path-is-inside": "~1.0.2",
-        "promise-inflight": "~1.0.1",
-        "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.1.0",
-        "qw": "~1.0.1",
-        "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
-        "read-installed": "~4.0.3",
-        "read-package-json": "^2.0.13",
-        "read-package-tree": "^5.2.1",
-        "readable-stream": "^2.3.6",
-        "readdir-scoped-modules": "*",
-        "request": "^2.86.0",
-        "retry": "^0.12.0",
-        "rimraf": "~2.6.2",
-        "safe-buffer": "^5.1.2",
-        "semver": "^5.5.0",
-        "sha": "~2.0.1",
-        "slide": "~1.1.6",
-        "sorted-object": "~2.0.1",
-        "sorted-union-stream": "~2.1.3",
-        "ssri": "^6.0.0",
-        "strip-ansi": "~4.0.0",
-        "tar": "^4.4.1",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
+        "JSONStream": "1.3.3",
+        "abbrev": "1.1.1",
+        "ansicolors": "0.3.2",
+        "ansistyles": "0.1.3",
+        "aproba": "1.2.0",
+        "archy": "1.0.0",
+        "bin-links": "1.1.2",
+        "bluebird": "3.5.1",
+        "byte-size": "4.0.3",
+        "cacache": "11.0.2",
+        "call-limit": "1.1.0",
+        "chownr": "1.0.1",
+        "cli-columns": "3.1.2",
+        "cli-table3": "0.5.0",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.11",
+        "debuglog": "1.0.1",
+        "detect-indent": "5.0.0",
+        "detect-newline": "2.1.0",
+        "dezalgo": "1.0.3",
+        "editor": "1.0.0",
+        "figgy-pudding": "3.1.0",
+        "find-npm-prefix": "1.0.2",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "gentle-fs": "2.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "has-unicode": "2.0.1",
+        "hosted-git-info": "2.6.0",
+        "iferr": "1.0.0",
+        "imurmurhash": "0.1.4",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ini": "1.3.5",
+        "init-package-json": "1.10.3",
+        "is-cidr": "2.0.6",
+        "json-parse-better-errors": "1.0.2",
+        "lazy-property": "1.0.0",
+        "libcipm": "2.0.0",
+        "libnpmhook": "4.0.1",
+        "libnpx": "10.2.0",
+        "lock-verify": "2.0.2",
+        "lockfile": "1.0.4",
+        "lodash._baseindexof": "3.1.0",
+        "lodash._baseuniq": "4.6.0",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2",
+        "lodash._getnative": "3.9.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.restparam": "3.6.1",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.without": "4.4.0",
+        "lru-cache": "4.1.3",
+        "meant": "1.0.1",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "node-gyp": "3.7.0",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.4.0",
+        "npm-audit-report": "1.3.1",
+        "npm-cache-filename": "1.0.2",
+        "npm-install-checks": "3.0.0",
+        "npm-lifecycle": "2.0.3",
+        "npm-package-arg": "6.1.0",
+        "npm-packlist": "1.1.10",
+        "npm-pick-manifest": "2.1.0",
+        "npm-profile": "3.0.2",
+        "npm-registry-client": "8.5.1",
+        "npm-registry-fetch": "1.1.0",
+        "npm-user-validate": "1.0.0",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "opener": "1.4.3",
+        "osenv": "0.1.5",
+        "pacote": "8.1.6",
+        "path-is-inside": "1.0.2",
+        "promise-inflight": "1.0.1",
+        "qrcode-terminal": "0.12.0",
+        "query-string": "6.1.0",
+        "qw": "1.0.1",
+        "read": "1.0.7",
+        "read-cmd-shim": "1.0.1",
+        "read-installed": "4.0.3",
+        "read-package-json": "2.0.13",
+        "read-package-tree": "5.2.1",
+        "readable-stream": "2.3.6",
+        "readdir-scoped-modules": "1.0.2",
+        "request": "2.81.0",
+        "retry": "0.12.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.2",
+        "semver": "5.5.0",
+        "sha": "2.0.1",
+        "slide": "1.1.6",
+        "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
+        "ssri": "6.0.0",
+        "tar": "4.4.4",
+        "text-table": "0.2.0",
+        "tiny-relative-date": "1.3.0",
         "uid-number": "0.0.6",
-        "umask": "~1.1.0",
-        "unique-filename": "~1.1.0",
-        "unpipe": "~1.0.0",
-        "update-notifier": "^2.5.0",
-        "uuid": "^3.2.1",
-        "validate-npm-package-license": "^3.0.3",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "~1.3.0",
-        "worker-farm": "^1.6.0",
-        "wrappy": "~1.0.2",
-        "write-file-atomic": "^2.3.0"
+        "umask": "1.1.0",
+        "unique-filename": "1.1.0",
+        "unpipe": "1.0.0",
+        "update-notifier": "2.5.0",
+        "uuid": "3.3.2",
+        "validate-npm-package-license": "3.0.3",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.3.1",
+        "worker-farm": "1.6.0",
+        "wrappy": "1.0.2",
+        "write-file-atomic": "2.3.0"
       },
       "dependencies": {
         "JSONStream": {
-          "version": "1.3.2",
+          "version": "1.3.3",
           "bundled": true,
           "requires": {
-            "jsonparse": "^1.2.0",
-            "through": ">=2.2.7 <3"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
-            }
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
           }
         },
         "abbrev": {
           "version": "1.1.1",
           "bundled": true
         },
+        "agent-base": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "es6-promisify": "5.0.0"
+          }
+        },
+        "agentkeepalive": {
+          "version": "3.4.1",
+          "bundled": true,
+          "requires": {
+            "humanize-ms": "1.2.1"
+          }
+        },
+        "ansi-align": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "2.1.1"
+          }
+        },
         "ansi-regex": {
-          "version": "3.0.0",
+          "version": "2.1.1",
           "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
         },
         "ansicolors": {
           "version": "0.3.2",
@@ -1993,19 +2008,114 @@
           "version": "1.0.0",
           "bundled": true
         },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.7.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
         "bin-links": {
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "cmd-shim": "^2.0.2",
-            "gentle-fs": "^2.0.0",
-            "graceful-fs": "^4.1.11",
-            "write-file-atomic": "^2.3.0"
+            "bluebird": "3.5.1",
+            "cmd-shim": "2.0.2",
+            "gentle-fs": "2.0.1",
+            "graceful-fs": "4.1.11",
+            "write-file-atomic": "2.3.0"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
           }
         },
         "bluebird": {
           "version": "3.5.1",
+          "bundled": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "boxen": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "ansi-align": "2.0.0",
+            "camelcase": "4.1.0",
+            "chalk": "2.4.1",
+            "cli-boxes": "1.0.0",
+            "string-width": "2.1.1",
+            "term-size": "1.2.0",
+            "widest-line": "2.0.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-from": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "builtins": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "byline": {
+          "version": "5.0.0",
           "bundled": true
         },
         "byte-size": {
@@ -2016,210 +2126,302 @@
           "version": "11.0.2",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "chownr": "^1.0.1",
-            "figgy-pudding": "^3.1.0",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.2",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "ssri": "^6.0.0",
-            "unique-filename": "^1.1.0",
-            "y18n": "^4.0.0"
-          },
-          "dependencies": {
-            "y18n": {
-              "version": "4.0.0",
-              "bundled": true
-            }
+            "bluebird": "3.5.1",
+            "chownr": "1.0.1",
+            "figgy-pudding": "3.1.0",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lru-cache": "4.1.3",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.2",
+            "ssri": "6.0.0",
+            "unique-filename": "1.1.0",
+            "y18n": "4.0.0"
           }
         },
         "call-limit": {
           "version": "1.1.0",
           "bundled": true
         },
+        "camelcase": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "capture-stack-trace": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
         "chownr": {
           "version": "1.0.1",
+          "bundled": true
+        },
+        "ci-info": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "cidr-regex": {
+          "version": "2.0.9",
+          "bundled": true,
+          "requires": {
+            "ip-regex": "2.1.0"
+          }
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
           "bundled": true
         },
         "cli-columns": {
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "^2.0.0",
-            "strip-ansi": "^3.0.1"
+            "string-width": "2.1.1",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "cli-table3": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "colors": "1.3.0",
+            "object-assign": "4.1.1",
+            "string-width": "2.1.1"
+          }
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
-            "string-width": {
-              "version": "2.1.1",
-              "bundled": true,
-              "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-              },
-              "dependencies": {
-                "is-fullwidth-code-point": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "strip-ansi": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "^3.0.0"
-                  }
-                }
-              }
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
             },
             "strip-ansi": {
-              "version": "3.0.1",
+              "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "bundled": true
-                }
+                "ansi-regex": "3.0.0"
               }
             }
           }
         },
-        "cli-table2": {
-          "version": "0.2.0",
-          "bundled": true,
-          "requires": {
-            "colors": "^1.1.2",
-            "lodash": "^3.10.1",
-            "string-width": "^1.0.1"
-          },
-          "dependencies": {
-            "colors": {
-              "version": "1.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              },
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.1.0",
-                  "bundled": true
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            }
-          }
+        "clone": {
+          "version": "1.0.4",
+          "bundled": true
         },
         "cmd-shim": {
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "~0.5.0"
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1"
           }
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "colors": {
+          "version": "1.3.0",
+          "bundled": true,
+          "optional": true
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
           "requires": {
-            "strip-ansi": "^3.0.0",
-            "wcwidth": "^1.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "bundled": true
-                }
-              }
-            },
-            "wcwidth": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "defaults": "^1.0.3"
-              },
-              "dependencies": {
-                "defaults": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "clone": "^1.0.2"
-                  },
-                  "dependencies": {
-                    "clone": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            }
+            "strip-ansi": "3.0.1",
+            "wcwidth": "1.0.1"
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "buffer-from": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "typedarray": "0.0.6"
           }
         },
         "config-chain": {
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ini": "^1.3.4",
-            "proto-list": "~1.2.1"
+            "ini": "1.3.5",
+            "proto-list": "1.2.4"
+          }
+        },
+        "configstore": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "dot-prop": "4.2.0",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.3.0",
+            "unique-string": "1.0.0",
+            "write-file-atomic": "2.3.0",
+            "xdg-basedir": "3.0.0"
+          }
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "copy-concurrently": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "fs-write-stream-atomic": "1.0.10",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
           },
           "dependencies": {
-            "proto-list": {
-              "version": "1.2.4",
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true
+            }
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "create-error-class": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "capture-stack-trace": "1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
+          }
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "crypto-random-string": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cyclist": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
               "bundled": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
+          "bundled": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "defaults": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "clone": "1.0.4"
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
           "bundled": true
         },
         "detect-indent": {
@@ -2234,18 +2436,106 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "asap": "^2.0.0",
-            "wrappy": "1"
-          },
-          "dependencies": {
-            "asap": {
-              "version": "2.0.5",
-              "bundled": true
-            }
+            "asap": "2.0.6",
+            "wrappy": "1.0.2"
+          }
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "is-obj": "1.0.1"
+          }
+        },
+        "dotenv": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "duplexify": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "stream-shift": "1.0.0"
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
           }
         },
         "editor": {
           "version": "1.0.0",
+          "bundled": true
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.23"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0"
+          }
+        },
+        "err-code": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "errno": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "prr": "1.0.1"
+          }
+        },
+        "es6-promise": {
+          "version": "4.2.4",
+          "bundled": true
+        },
+        "es6-promisify": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "es6-promise": "4.2.4"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extsprintf": {
+          "version": "1.3.0",
           "bundled": true
         },
         "figgy-pudding": {
@@ -2256,23 +2546,66 @@
           "version": "1.0.2",
           "bundled": true
         },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "flush-write-stream": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "from2": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "minipass": "2.3.3"
+          }
+        },
         "fs-vacuum": {
           "version": "1.2.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "path-is-inside": "^1.0.1",
-            "rimraf": "^2.5.2"
+            "graceful-fs": "4.1.11",
+            "path-is-inside": "1.0.2",
+            "rimraf": "2.6.2"
           }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "iferr": "^0.1.5",
-            "imurmurhash": "^0.1.4",
-            "readable-stream": "1 || 2"
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.3.6"
           },
           "dependencies": {
             "iferr": {
@@ -2281,22 +2614,86 @@
             }
           }
         },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "genfun": {
+          "version": "4.0.1",
+          "bundled": true
+        },
         "gentle-fs": {
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.2",
-            "fs-vacuum": "^1.2.10",
-            "graceful-fs": "^4.1.11",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "path-is-inside": "^1.0.2",
-            "read-cmd-shim": "^1.0.1",
-            "slide": "^1.1.6"
+            "aproba": "1.2.0",
+            "fs-vacuum": "1.2.10",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "path-is-inside": "1.0.2",
+            "read-cmd-shim": "1.0.1",
+            "slide": "1.1.6"
           },
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
+              "bundled": true
+            }
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
               "bundled": true
             }
           }
@@ -2305,65 +2702,146 @@
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          },
-          "dependencies": {
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            }
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "global-dirs": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "ini": "1.3.5"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "bundled": true,
+          "requires": {
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "safe-buffer": "5.1.2",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true
         },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "4.11.8",
+              "bundled": true,
+              "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
         "has-unicode": {
           "version": "2.0.1",
+          "bundled": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
           "bundled": true
         },
         "hosted-git-info": {
           "version": "2.6.0",
           "bundled": true
         },
+        "http-cache-semantics": {
+          "version": "3.8.1",
+          "bundled": true
+        },
+        "http-proxy-agent": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "agent-base": "4.2.0",
+            "debug": "3.1.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.2"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "agent-base": "4.2.0",
+            "debug": "3.1.0"
+          }
+        },
+        "humanize-ms": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
         "iferr": {
           "version": "1.0.0",
+          "bundled": true
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "import-lazy": {
+          "version": "2.1.0",
           "bundled": true
         },
         "imurmurhash": {
@@ -2374,8 +2852,8 @@
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -2390,963 +2868,209 @@
           "version": "1.10.3",
           "bundled": true,
           "requires": {
-            "glob": "^7.1.1",
-            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-            "promzard": "^0.3.0",
-            "read": "~1.0.1",
-            "read-package-json": "1 || 2",
-            "semver": "2.x || 3.x || 4 || 5",
-            "validate-npm-package-license": "^3.0.1",
-            "validate-npm-package-name": "^3.0.0"
-          },
-          "dependencies": {
-            "promzard": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "read": "1"
-              }
-            }
+            "glob": "7.1.2",
+            "npm-package-arg": "6.1.0",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.13",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3",
+            "validate-npm-package-name": "3.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ip": {
+          "version": "1.1.5",
+          "bundled": true
+        },
+        "ip-regex": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-ci": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ci-info": "1.1.3"
           }
         },
         "is-cidr": {
-          "version": "2.0.5",
+          "version": "2.0.6",
           "bundled": true,
           "requires": {
-            "cidr-regex": "^2.0.8"
-          },
-          "dependencies": {
-            "cidr-regex": {
-              "version": "2.0.8",
-              "bundled": true,
-              "requires": {
-                "ip-regex": "^2.1.0"
-              },
-              "dependencies": {
-                "ip-regex": {
-                  "version": "2.1.0",
-                  "bundled": true
-                }
-              }
-            }
+            "cidr-regex": "2.0.9"
           }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-installed-globally": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "global-dirs": "0.1.1",
+            "is-path-inside": "1.0.1"
+          }
+        },
+        "is-npm": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "path-is-inside": "1.0.2"
+          }
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
           "bundled": true
         },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsonparse": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "package-json": "4.0.1"
+          }
+        },
         "lazy-property": {
           "version": "1.0.0",
           "bundled": true
         },
-        "libcipm": {
-          "version": "1.6.2",
+        "lcid": {
+          "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "bin-links": "^1.1.0",
-            "bluebird": "^3.5.1",
-            "find-npm-prefix": "^1.0.2",
-            "graceful-fs": "^4.1.11",
-            "lock-verify": "^2.0.0",
-            "npm-lifecycle": "^2.0.0",
-            "npm-logical-tree": "^1.2.1",
-            "npm-package-arg": "^6.0.0",
-            "pacote": "^7.5.1",
-            "protoduck": "^5.0.0",
-            "read-package-json": "^2.0.12",
-            "rimraf": "^2.6.2",
-            "worker-farm": "^1.5.4"
-          },
-          "dependencies": {
-            "npm-logical-tree": {
-              "version": "1.2.1",
-              "bundled": true
-            },
-            "pacote": {
-              "version": "7.6.1",
-              "bundled": true,
-              "requires": {
-                "bluebird": "^3.5.1",
-                "cacache": "^10.0.4",
-                "get-stream": "^3.0.0",
-                "glob": "^7.1.2",
-                "lru-cache": "^4.1.1",
-                "make-fetch-happen": "^2.6.0",
-                "minimatch": "^3.0.4",
-                "mississippi": "^3.0.0",
-                "mkdirp": "^0.5.1",
-                "normalize-package-data": "^2.4.0",
-                "npm-package-arg": "^6.0.0",
-                "npm-packlist": "^1.1.10",
-                "npm-pick-manifest": "^2.1.0",
-                "osenv": "^0.1.5",
-                "promise-inflight": "^1.0.1",
-                "promise-retry": "^1.1.1",
-                "protoduck": "^5.0.0",
-                "rimraf": "^2.6.2",
-                "safe-buffer": "^5.1.1",
-                "semver": "^5.5.0",
-                "ssri": "^5.2.4",
-                "tar": "^4.4.0",
-                "unique-filename": "^1.1.0",
-                "which": "^1.3.0"
-              },
-              "dependencies": {
-                "cacache": {
-                  "version": "10.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "bluebird": "^3.5.1",
-                    "chownr": "^1.0.1",
-                    "glob": "^7.1.2",
-                    "graceful-fs": "^4.1.11",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^2.0.0",
-                    "mkdirp": "^0.5.1",
-                    "move-concurrently": "^1.0.1",
-                    "promise-inflight": "^1.0.1",
-                    "rimraf": "^2.6.2",
-                    "ssri": "^5.2.4",
-                    "unique-filename": "^1.1.0",
-                    "y18n": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "mississippi": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^2.0.1",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "concat-stream": {
-                          "version": "1.6.2",
-                          "bundled": true,
-                          "requires": {
-                            "buffer-from": "^1.0.0",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
-                          },
-                          "dependencies": {
-                            "buffer-from": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "typedarray": {
-                              "version": "0.0.6",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.5.4",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "end-of-stream": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "requires": {
-                            "once": "^1.4.0"
-                          }
-                        },
-                        "flush-write-stream": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
-                          }
-                        },
-                        "from2": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
-                          }
-                        },
-                        "parallel-transform": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
-                          },
-                          "dependencies": {
-                            "cyclist": {
-                              "version": "0.2.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
-                          }
-                        },
-                        "pumpify": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
-                          }
-                        },
-                        "stream-each": {
-                          "version": "1.2.2",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
-                          },
-                          "dependencies": {
-                            "xtend": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "y18n": {
-                      "version": "4.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "get-stream": {
-                  "version": "3.0.0",
-                  "bundled": true
-                },
-                "make-fetch-happen": {
-                  "version": "2.6.0",
-                  "bundled": true,
-                  "requires": {
-                    "agentkeepalive": "^3.3.0",
-                    "cacache": "^10.0.0",
-                    "http-cache-semantics": "^3.8.0",
-                    "http-proxy-agent": "^2.0.0",
-                    "https-proxy-agent": "^2.1.0",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^1.2.0",
-                    "node-fetch-npm": "^2.0.2",
-                    "promise-retry": "^1.1.1",
-                    "socks-proxy-agent": "^3.0.1",
-                    "ssri": "^5.0.0"
-                  },
-                  "dependencies": {
-                    "agentkeepalive": {
-                      "version": "3.4.1",
-                      "bundled": true,
-                      "requires": {
-                        "humanize-ms": "^1.2.1"
-                      },
-                      "dependencies": {
-                        "humanize-ms": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "http-cache-semantics": {
-                      "version": "3.8.1",
-                      "bundled": true
-                    },
-                    "http-proxy-agent": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "4",
-                        "debug": "3.1.0"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "https-proxy-agent": {
-                      "version": "2.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^3.1.0"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "mississippi": {
-                      "version": "1.3.1",
-                      "bundled": true,
-                      "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^1.0.0",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "concat-stream": {
-                          "version": "1.6.2",
-                          "bundled": true,
-                          "requires": {
-                            "buffer-from": "^1.0.0",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
-                          },
-                          "dependencies": {
-                            "buffer-from": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "typedarray": {
-                              "version": "0.0.6",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.5.4",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "end-of-stream": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "requires": {
-                            "once": "^1.4.0"
-                          }
-                        },
-                        "flush-write-stream": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
-                          }
-                        },
-                        "from2": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
-                          }
-                        },
-                        "parallel-transform": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
-                          },
-                          "dependencies": {
-                            "cyclist": {
-                              "version": "0.2.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "pump": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
-                          }
-                        },
-                        "pumpify": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "pump": {
-                              "version": "2.0.1",
-                              "bundled": true,
-                              "requires": {
-                                "end-of-stream": "^1.1.0",
-                                "once": "^1.3.1"
-                              }
-                            }
-                          }
-                        },
-                        "stream-each": {
-                          "version": "1.2.2",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
-                          },
-                          "dependencies": {
-                            "xtend": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "node-fetch-npm": {
-                      "version": "2.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "encoding": "^0.1.11",
-                        "json-parse-better-errors": "^1.0.0",
-                        "safe-buffer": "^5.1.1"
-                      },
-                      "dependencies": {
-                        "encoding": {
-                          "version": "0.1.12",
-                          "bundled": true,
-                          "requires": {
-                            "iconv-lite": "~0.4.13"
-                          },
-                          "dependencies": {
-                            "iconv-lite": {
-                              "version": "0.4.21",
-                              "bundled": true,
-                              "requires": {
-                                "safer-buffer": "^2.1.0"
-                              },
-                              "dependencies": {
-                                "safer-buffer": {
-                                  "version": "2.1.2",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks-proxy-agent": {
-                      "version": "3.0.1",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "^4.1.0",
-                        "socks": "^1.1.10"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "socks": {
-                          "version": "1.1.10",
-                          "bundled": true,
-                          "requires": {
-                            "ip": "^1.1.4",
-                            "smart-buffer": "^1.0.13"
-                          },
-                          "dependencies": {
-                            "ip": {
-                              "version": "1.1.5",
-                              "bundled": true
-                            },
-                            "smart-buffer": {
-                              "version": "1.1.15",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.11",
-                      "bundled": true,
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "promise-retry": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
-                  },
-                  "dependencies": {
-                    "err-code": {
-                      "version": "1.1.2",
-                      "bundled": true
-                    },
-                    "retry": {
-                      "version": "0.10.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "ssri": {
-                  "version": "5.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "^5.1.1"
-                  }
-                }
-              }
-            },
-            "protoduck": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "genfun": "^4.0.1"
-              },
-              "dependencies": {
-                "genfun": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            }
+            "invert-kv": "1.0.0"
+          }
+        },
+        "libcipm": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "bin-links": "1.1.2",
+            "bluebird": "3.5.1",
+            "find-npm-prefix": "1.0.2",
+            "graceful-fs": "4.1.11",
+            "lock-verify": "2.0.2",
+            "npm-lifecycle": "2.0.3",
+            "npm-logical-tree": "1.2.1",
+            "npm-package-arg": "6.1.0",
+            "pacote": "8.1.6",
+            "protoduck": "5.0.0",
+            "read-package-json": "2.0.13",
+            "rimraf": "2.6.2",
+            "worker-farm": "1.6.0"
           }
         },
         "libnpmhook": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "figgy-pudding": "^3.1.0",
-            "npm-registry-fetch": "^3.0.0"
+            "figgy-pudding": "3.1.0",
+            "npm-registry-fetch": "3.1.1"
           },
           "dependencies": {
             "npm-registry-fetch": {
               "version": "3.1.1",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "figgy-pudding": "^3.1.0",
-                "lru-cache": "^4.1.2",
-                "make-fetch-happen": "^4.0.0",
-                "npm-package-arg": "^6.0.0"
-              },
-              "dependencies": {
-                "make-fetch-happen": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agentkeepalive": "^3.4.1",
-                    "cacache": "^11.0.1",
-                    "http-cache-semantics": "^3.8.1",
-                    "http-proxy-agent": "^2.1.0",
-                    "https-proxy-agent": "^2.2.1",
-                    "lru-cache": "^4.1.2",
-                    "mississippi": "^3.0.0",
-                    "node-fetch-npm": "^2.0.2",
-                    "promise-retry": "^1.1.1",
-                    "socks-proxy-agent": "^4.0.0",
-                    "ssri": "^6.0.0"
-                  },
-                  "dependencies": {
-                    "agentkeepalive": {
-                      "version": "3.4.1",
-                      "bundled": true,
-                      "requires": {
-                        "humanize-ms": "^1.2.1"
-                      },
-                      "dependencies": {
-                        "humanize-ms": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "http-cache-semantics": {
-                      "version": "3.8.1",
-                      "bundled": true
-                    },
-                    "http-proxy-agent": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "4",
-                        "debug": "3.1.0"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "https-proxy-agent": {
-                      "version": "2.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^3.1.0"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "node-fetch-npm": {
-                      "version": "2.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "encoding": "^0.1.11",
-                        "json-parse-better-errors": "^1.0.0",
-                        "safe-buffer": "^5.1.1"
-                      },
-                      "dependencies": {
-                        "encoding": {
-                          "version": "0.1.12",
-                          "bundled": true,
-                          "requires": {
-                            "iconv-lite": "~0.4.13"
-                          },
-                          "dependencies": {
-                            "iconv-lite": {
-                              "version": "0.4.21",
-                              "bundled": true,
-                              "requires": {
-                                "safer-buffer": "^2.1.0"
-                              },
-                              "dependencies": {
-                                "safer-buffer": {
-                                  "version": "2.1.2",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "promise-retry": {
-                      "version": "1.1.1",
-                      "bundled": true,
-                      "requires": {
-                        "err-code": "^1.0.0",
-                        "retry": "^0.10.0"
-                      },
-                      "dependencies": {
-                        "err-code": {
-                          "version": "1.1.2",
-                          "bundled": true
-                        },
-                        "retry": {
-                          "version": "0.10.1",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "socks-proxy-agent": {
-                      "version": "4.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "~4.1.0",
-                        "socks": "~2.1.6"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.1.2",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "socks": {
-                          "version": "2.1.6",
-                          "bundled": true,
-                          "requires": {
-                            "ip": "^1.1.5",
-                            "smart-buffer": "^4.0.1"
-                          },
-                          "dependencies": {
-                            "ip": {
-                              "version": "1.1.5",
-                              "bundled": true
-                            },
-                            "smart-buffer": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
+                "bluebird": "3.5.1",
+                "figgy-pudding": "3.1.0",
+                "lru-cache": "4.1.3",
+                "make-fetch-happen": "4.0.1",
+                "npm-package-arg": "6.1.0"
               }
             }
           }
@@ -3355,336 +3079,37 @@
           "version": "10.2.0",
           "bundled": true,
           "requires": {
-            "dotenv": "^5.0.1",
-            "npm-package-arg": "^6.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.3.0",
-            "which": "^1.3.0",
-            "y18n": "^4.0.0",
-            "yargs": "^11.0.0"
-          },
-          "dependencies": {
-            "dotenv": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "yargs": {
-              "version": "11.0.0",
-              "bundled": true,
-              "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
-              },
-              "dependencies": {
-                "cliui": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "^2.1.1",
-                    "strip-ansi": "^4.0.0",
-                    "wrap-ansi": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "wrap-ansi": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
-                      },
-                      "dependencies": {
-                        "string-width": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "code-point-at": "^1.0.0",
-                            "is-fullwidth-code-point": "^1.0.0",
-                            "strip-ansi": "^3.0.0"
-                          },
-                          "dependencies": {
-                            "code-point-at": {
-                              "version": "1.1.0",
-                              "bundled": true
-                            },
-                            "is-fullwidth-code-point": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "number-is-nan": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.1",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "ansi-regex": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "bundled": true
-                },
-                "find-up": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "locate-path": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "locate-path": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
-                      },
-                      "dependencies": {
-                        "p-locate": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "p-limit": "^1.1.0"
-                          },
-                          "dependencies": {
-                            "p-limit": {
-                              "version": "1.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "p-try": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "p-try": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-exists": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "get-caller-file": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "os-locale": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "execa": "^0.7.0",
-                    "lcid": "^1.0.0",
-                    "mem": "^1.1.0"
-                  },
-                  "dependencies": {
-                    "execa": {
-                      "version": "0.7.0",
-                      "bundled": true,
-                      "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "cross-spawn": {
-                          "version": "5.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "lru-cache": "^4.0.1",
-                            "shebang-command": "^1.2.0",
-                            "which": "^1.2.9"
-                          },
-                          "dependencies": {
-                            "shebang-command": {
-                              "version": "1.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "shebang-regex": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "shebang-regex": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "npm-run-path": {
-                          "version": "2.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "path-key": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "path-key": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "p-finally": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "signal-exit": {
-                          "version": "3.0.2",
-                          "bundled": true
-                        },
-                        "strip-eof": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "lcid": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "invert-kv": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "invert-kv": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "mem": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "mimic-fn": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "mimic-fn": {
-                          "version": "1.2.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "require-directory": {
-                  "version": "2.1.1",
-                  "bundled": true
-                },
-                "require-main-filename": {
-                  "version": "1.0.1",
-                  "bundled": true
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "^2.0.0",
-                    "strip-ansi": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "which-module": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "y18n": {
-                  "version": "3.2.1",
-                  "bundled": true
-                },
-                "yargs-parser": {
-                  "version": "9.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "camelcase": "^4.1.0"
-                  },
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "4.1.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            }
+            "dotenv": "5.0.1",
+            "npm-package-arg": "6.1.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "update-notifier": "2.5.0",
+            "which": "1.3.1",
+            "y18n": "4.0.0",
+            "yargs": "11.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "lock-verify": {
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^5.1.2 || 6",
-            "semver": "^5.4.1"
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
           }
         },
         "lockfile": {
           "version": "1.0.4",
           "bundled": true,
           "requires": {
-            "signal-exit": "^3.0.2"
-          },
-          "dependencies": {
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true
-            }
+            "signal-exit": "3.0.2"
           }
         },
         "lodash._baseindexof": {
@@ -3695,18 +3120,8 @@
           "version": "4.6.0",
           "bundled": true,
           "requires": {
-            "lodash._createset": "~4.0.0",
-            "lodash._root": "~3.0.0"
-          },
-          "dependencies": {
-            "lodash._createset": {
-              "version": "4.0.3",
-              "bundled": true
-            },
-            "lodash._root": {
-              "version": "3.0.1",
-              "bundled": true
-            }
+            "lodash._createset": "4.0.3",
+            "lodash._root": "3.0.1"
           }
         },
         "lodash._bindcallback": {
@@ -3721,11 +3136,19 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "lodash._getnative": "^3.0.0"
+            "lodash._getnative": "3.9.1"
           }
+        },
+        "lodash._createset": {
+          "version": "4.0.3",
+          "bundled": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
+          "bundled": true
+        },
+        "lodash._root": {
+          "version": "3.0.1",
           "bundled": true
         },
         "lodash.clonedeep": {
@@ -3748,168 +3171,114 @@
           "version": "4.4.0",
           "bundled": true
         },
+        "lowercase-keys": {
+          "version": "1.0.1",
+          "bundled": true
+        },
         "lru-cache": {
           "version": "4.1.3",
           "bundled": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          },
-          "dependencies": {
-            "pseudomap": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true
-            }
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "pify": "3.0.0"
+          }
+        },
+        "make-fetch-happen": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "agentkeepalive": "3.4.1",
+            "cacache": "11.0.2",
+            "http-cache-semantics": "3.8.1",
+            "http-proxy-agent": "2.1.0",
+            "https-proxy-agent": "2.2.1",
+            "lru-cache": "4.1.3",
+            "mississippi": "3.0.0",
+            "node-fetch-npm": "2.0.2",
+            "promise-retry": "1.1.1",
+            "socks-proxy-agent": "4.0.1",
+            "ssri": "6.0.0"
           }
         },
         "meant": {
           "version": "1.0.1",
           "bundled": true
         },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "1.2.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.33.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
+          },
+          "dependencies": {
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "minipass": "2.3.3"
+          }
+        },
         "mississippi": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
-          },
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.6.1",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-              },
-              "dependencies": {
-                "typedarray": {
-                  "version": "0.0.6",
-                  "bundled": true
-                }
-              }
-            },
-            "duplexify": {
-              "version": "3.5.4",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "end-of-stream": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "once": "^1.4.0"
-              }
-            },
-            "flush-write-stream": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
-              }
-            },
-            "from2": {
-              "version": "2.3.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
-              }
-            },
-            "parallel-transform": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "cyclist": "~0.2.2",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
-              },
-              "dependencies": {
-                "cyclist": {
-                  "version": "0.2.2",
-                  "bundled": true
-                }
-              }
-            },
-            "pump": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            },
-            "pumpify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "duplexify": "^3.5.3",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
-              },
-              "dependencies": {
-                "pump": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
-                  }
-                }
-              }
-            },
-            "stream-each": {
-              "version": "1.2.2",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "through2": {
-              "version": "2.0.3",
-              "bundled": true,
-              "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
-              },
-              "dependencies": {
-                "xtend": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            }
+            "concat-stream": "1.6.2",
+            "duplexify": "3.6.0",
+            "end-of-stream": "1.4.1",
+            "flush-write-stream": "1.0.3",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "3.0.0",
+            "pumpify": "1.5.1",
+            "stream-each": "1.2.2",
+            "through2": "2.0.3"
           }
         },
         "mkdirp": {
@@ -3917,114 +3286,60 @@
           "bundled": true,
           "requires": {
             "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            }
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.1",
-            "copy-concurrently": "^1.0.0",
-            "fs-write-stream-atomic": "^1.0.8",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.3"
-          },
-          "dependencies": {
-            "copy-concurrently": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
-              },
-              "dependencies": {
-                "iferr": {
-                  "version": "0.1.5",
-                  "bundled": true
-                }
-              }
-            },
-            "run-queue": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "^1.1.1"
-              }
-            }
+            "aproba": "1.2.0",
+            "copy-concurrently": "1.0.5",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "node-fetch-npm": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "encoding": "0.1.12",
+            "json-parse-better-errors": "1.0.2",
+            "safe-buffer": "5.1.2"
           }
         },
         "node-gyp": {
-          "version": "3.6.2",
+          "version": "3.7.0",
           "bundled": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "glob": "^7.0.3",
-            "graceful-fs": "^4.1.2",
-            "minimatch": "^3.0.2",
-            "mkdirp": "^0.5.0",
-            "nopt": "2 || 3",
-            "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
-            "request": "2",
-            "rimraf": "2",
-            "semver": "~5.3.0",
-            "tar": "^2.0.0",
-            "which": "1"
+            "fstream": "1.0.11",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.1.2",
+            "osenv": "0.1.5",
+            "request": "2.81.0",
+            "rimraf": "2.6.2",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.3.1"
           },
           "dependencies": {
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
             "nopt": {
               "version": "3.0.6",
               "bundled": true,
               "requires": {
-                "abbrev": "1"
+                "abbrev": "1.1.1"
               }
             },
             "semver": {
@@ -4035,18 +3350,9 @@
               "version": "2.2.1",
               "bundled": true,
               "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
-              },
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "~2.0.0"
-                  }
-                }
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
               }
             }
           }
@@ -4055,48 +3361,31 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          },
-          "dependencies": {
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "builtin-modules": "^1.0.0"
-              },
-              "dependencies": {
-                "builtin-modules": {
-                  "version": "1.1.1",
-                  "bundled": true
-                }
-              }
-            }
+            "hosted-git-info": "2.6.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3"
           }
         },
         "npm-audit-report": {
-          "version": "1.2.1",
+          "version": "1.3.1",
           "bundled": true,
           "requires": {
-            "cli-table2": "^0.2.0",
-            "console-control-strings": "^1.1.0"
-          },
-          "dependencies": {
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            }
+            "cli-table3": "0.5.0",
+            "console-control-strings": "1.1.0"
           }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true
         },
         "npm-cache-filename": {
           "version": "1.0.2",
@@ -4106,686 +3395,79 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "semver": "^2.3.0 || 3.x || 4 || 5"
+            "semver": "5.5.0"
           }
         },
         "npm-lifecycle": {
           "version": "2.0.3",
           "bundled": true,
           "requires": {
-            "byline": "^5.0.0",
-            "graceful-fs": "^4.1.11",
-            "node-gyp": "^3.6.2",
-            "resolve-from": "^4.0.0",
-            "slide": "^1.1.6",
+            "byline": "5.0.0",
+            "graceful-fs": "4.1.11",
+            "node-gyp": "3.7.0",
+            "resolve-from": "4.0.0",
+            "slide": "1.1.6",
             "uid-number": "0.0.6",
-            "umask": "^1.1.0",
-            "which": "^1.3.0"
-          },
-          "dependencies": {
-            "byline": {
-              "version": "5.0.0",
-              "bundled": true
-            },
-            "resolve-from": {
-              "version": "4.0.0",
-              "bundled": true
-            }
+            "umask": "1.1.0",
+            "which": "1.3.1"
           }
+        },
+        "npm-logical-tree": {
+          "version": "1.2.1",
+          "bundled": true
         },
         "npm-package-arg": {
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.6.0",
-            "osenv": "^0.1.5",
-            "semver": "^5.5.0",
-            "validate-npm-package-name": "^3.0.0"
+            "hosted-git-info": "2.6.0",
+            "osenv": "0.1.5",
+            "semver": "5.5.0",
+            "validate-npm-package-name": "3.0.0"
           }
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          },
-          "dependencies": {
-            "ignore-walk": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "minimatch": "^3.0.4"
-              },
-              "dependencies": {
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "bundled": true,
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "npm-bundled": {
-              "version": "1.0.3",
-              "bundled": true
-            }
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npm-pick-manifest": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^6.0.0",
-            "semver": "^5.4.1"
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
           }
         },
         "npm-profile": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.2",
-            "make-fetch-happen": "^2.5.0"
-          },
-          "dependencies": {
-            "make-fetch-happen": {
-              "version": "2.6.0",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "^3.3.0",
-                "cacache": "^10.0.0",
-                "http-cache-semantics": "^3.8.0",
-                "http-proxy-agent": "^2.0.0",
-                "https-proxy-agent": "^2.1.0",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^1.2.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.0.0"
-              },
-              "dependencies": {
-                "agentkeepalive": {
-                  "version": "3.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "humanize-ms": "^1.2.1"
-                  },
-                  "dependencies": {
-                    "humanize-ms": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "cacache": {
-                  "version": "10.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "bluebird": "^3.5.1",
-                    "chownr": "^1.0.1",
-                    "glob": "^7.1.2",
-                    "graceful-fs": "^4.1.11",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^2.0.0",
-                    "mkdirp": "^0.5.1",
-                    "move-concurrently": "^1.0.1",
-                    "promise-inflight": "^1.0.1",
-                    "rimraf": "^2.6.2",
-                    "ssri": "^5.2.4",
-                    "unique-filename": "^1.1.0",
-                    "y18n": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "mississippi": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^2.0.1",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "concat-stream": {
-                          "version": "1.6.2",
-                          "bundled": true,
-                          "requires": {
-                            "buffer-from": "^1.0.0",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
-                          },
-                          "dependencies": {
-                            "buffer-from": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "typedarray": {
-                              "version": "0.0.6",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.5.4",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "end-of-stream": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "requires": {
-                            "once": "^1.4.0"
-                          }
-                        },
-                        "flush-write-stream": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
-                          }
-                        },
-                        "from2": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
-                          }
-                        },
-                        "parallel-transform": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
-                          },
-                          "dependencies": {
-                            "cyclist": {
-                              "version": "0.2.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
-                          }
-                        },
-                        "pumpify": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
-                          }
-                        },
-                        "stream-each": {
-                          "version": "1.2.2",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
-                          },
-                          "dependencies": {
-                            "xtend": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "y18n": {
-                      "version": "4.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "http-cache-semantics": {
-                  "version": "3.8.1",
-                  "bundled": true
-                },
-                "http-proxy-agent": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4",
-                    "debug": "3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "https-proxy-agent": {
-                  "version": "2.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "mississippi": {
-                  "version": "1.3.1",
-                  "bundled": true,
-                  "requires": {
-                    "concat-stream": "^1.5.0",
-                    "duplexify": "^3.4.2",
-                    "end-of-stream": "^1.1.0",
-                    "flush-write-stream": "^1.0.0",
-                    "from2": "^2.1.0",
-                    "parallel-transform": "^1.1.0",
-                    "pump": "^1.0.0",
-                    "pumpify": "^1.3.3",
-                    "stream-each": "^1.1.0",
-                    "through2": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "concat-stream": {
-                      "version": "1.6.0",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.2.2",
-                        "typedarray": "^0.0.6"
-                      },
-                      "dependencies": {
-                        "typedarray": {
-                          "version": "0.0.6",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "duplexify": {
-                      "version": "3.5.3",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "^1.0.0",
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0",
-                        "stream-shift": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "stream-shift": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "end-of-stream": {
-                      "version": "1.4.1",
-                      "bundled": true,
-                      "requires": {
-                        "once": "^1.4.0"
-                      }
-                    },
-                    "flush-write-stream": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.4"
-                      }
-                    },
-                    "from2": {
-                      "version": "2.3.0",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0"
-                      }
-                    },
-                    "parallel-transform": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "cyclist": "~0.2.2",
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.1.5"
-                      },
-                      "dependencies": {
-                        "cyclist": {
-                          "version": "0.2.2",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "pump": {
-                      "version": "1.0.3",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
-                      }
-                    },
-                    "pumpify": {
-                      "version": "1.4.0",
-                      "bundled": true,
-                      "requires": {
-                        "duplexify": "^3.5.3",
-                        "inherits": "^2.0.3",
-                        "pump": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
-                          }
-                        }
-                      }
-                    },
-                    "stream-each": {
-                      "version": "1.2.2",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "stream-shift": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "stream-shift": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "through2": {
-                      "version": "2.0.3",
-                      "bundled": true,
-                      "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
-                      },
-                      "dependencies": {
-                        "xtend": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "node-fetch-npm": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-better-errors": "^1.0.0",
-                    "safe-buffer": "^5.1.1"
-                  },
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "bundled": true,
-                      "requires": {
-                        "iconv-lite": "~0.4.13"
-                      },
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.19",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "json-parse-better-errors": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "promise-retry": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
-                  },
-                  "dependencies": {
-                    "err-code": {
-                      "version": "1.1.2",
-                      "bundled": true
-                    },
-                    "retry": {
-                      "version": "0.10.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "socks-proxy-agent": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "^4.1.0",
-                    "socks": "^1.1.10"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks": {
-                      "version": "1.1.10",
-                      "bundled": true,
-                      "requires": {
-                        "ip": "^1.1.4",
-                        "smart-buffer": "^1.0.13"
-                      },
-                      "dependencies": {
-                        "ip": {
-                          "version": "1.1.5",
-                          "bundled": true
-                        },
-                        "smart-buffer": {
-                          "version": "1.1.15",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "ssri": {
-                  "version": "5.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "^5.1.1"
-                  }
-                }
-              }
-            }
+            "aproba": "1.2.0",
+            "make-fetch-happen": "4.0.1"
           }
         },
         "npm-registry-client": {
           "version": "8.5.1",
           "bundled": true,
           "requires": {
-            "concat-stream": "^1.5.2",
-            "graceful-fs": "^4.1.6",
-            "normalize-package-data": "~1.0.1 || ^2.0.0",
-            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-            "npmlog": "2 || ^3.1.0 || ^4.0.0",
-            "once": "^1.3.3",
-            "request": "^2.74.0",
-            "retry": "^0.10.0",
-            "safe-buffer": "^5.1.1",
-            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-            "slide": "^1.1.3",
-            "ssri": "^5.2.4"
+            "concat-stream": "1.6.2",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "request": "2.81.0",
+            "retry": "0.10.1",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "ssri": "5.3.0"
           },
           "dependencies": {
-            "concat-stream": {
-              "version": "1.6.1",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-              },
-              "dependencies": {
-                "typedarray": {
-                  "version": "0.0.6",
-                  "bundled": true
-                }
-              }
-            },
             "retry": {
               "version": "0.10.1",
               "bundled": true
@@ -4794,7 +3476,7 @@
               "version": "5.3.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -4803,14 +3485,51 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "figgy-pudding": "^2.0.1",
-            "lru-cache": "^4.1.2",
-            "make-fetch-happen": "^3.0.0",
-            "npm-package-arg": "^6.0.0",
-            "safe-buffer": "^5.1.1"
+            "bluebird": "3.5.1",
+            "figgy-pudding": "2.0.1",
+            "lru-cache": "4.1.3",
+            "make-fetch-happen": "3.0.0",
+            "npm-package-arg": "6.1.0",
+            "safe-buffer": "5.1.2"
           },
           "dependencies": {
+            "cacache": {
+              "version": "10.0.4",
+              "bundled": true,
+              "requires": {
+                "bluebird": "3.5.1",
+                "chownr": "1.0.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.3",
+                "mississippi": "2.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.2",
+                "ssri": "5.3.0",
+                "unique-filename": "1.1.0",
+                "y18n": "4.0.0"
+              },
+              "dependencies": {
+                "mississippi": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "concat-stream": "1.6.2",
+                    "duplexify": "3.6.0",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.3",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "2.0.1",
+                    "pumpify": "1.5.1",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
+                  }
+                }
+              }
+            },
             "figgy-pudding": {
               "version": "2.0.1",
               "bundled": true
@@ -4819,407 +3538,61 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^10.0.4",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.0",
-                "lru-cache": "^4.1.2",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.2.4"
-              },
-              "dependencies": {
-                "agentkeepalive": {
-                  "version": "3.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "humanize-ms": "^1.2.1"
-                  },
-                  "dependencies": {
-                    "humanize-ms": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "cacache": {
-                  "version": "10.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "bluebird": "^3.5.1",
-                    "chownr": "^1.0.1",
-                    "glob": "^7.1.2",
-                    "graceful-fs": "^4.1.11",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^2.0.0",
-                    "mkdirp": "^0.5.1",
-                    "move-concurrently": "^1.0.1",
-                    "promise-inflight": "^1.0.1",
-                    "rimraf": "^2.6.2",
-                    "ssri": "^5.2.4",
-                    "unique-filename": "^1.1.0",
-                    "y18n": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "mississippi": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^2.0.1",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "concat-stream": {
-                          "version": "1.6.2",
-                          "bundled": true,
-                          "requires": {
-                            "buffer-from": "^1.0.0",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
-                          },
-                          "dependencies": {
-                            "buffer-from": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "typedarray": {
-                              "version": "0.0.6",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.5.4",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "end-of-stream": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "requires": {
-                            "once": "^1.4.0"
-                          }
-                        },
-                        "flush-write-stream": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
-                          }
-                        },
-                        "from2": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
-                          }
-                        },
-                        "parallel-transform": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
-                          },
-                          "dependencies": {
-                            "cyclist": {
-                              "version": "0.2.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
-                          }
-                        },
-                        "pumpify": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
-                          }
-                        },
-                        "stream-each": {
-                          "version": "1.2.2",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
-                          },
-                          "dependencies": {
-                            "xtend": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "y18n": {
-                      "version": "4.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "http-cache-semantics": {
-                  "version": "3.8.1",
-                  "bundled": true
-                },
-                "http-proxy-agent": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4",
-                    "debug": "3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "https-proxy-agent": {
-                  "version": "2.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "node-fetch-npm": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-better-errors": "^1.0.0",
-                    "safe-buffer": "^5.1.1"
-                  },
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "bundled": true,
-                      "requires": {
-                        "iconv-lite": "~0.4.13"
-                      },
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.21",
-                          "bundled": true,
-                          "requires": {
-                            "safer-buffer": "^2.1.0"
-                          },
-                          "dependencies": {
-                            "safer-buffer": {
-                              "version": "2.1.2",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "promise-retry": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
-                  },
-                  "dependencies": {
-                    "err-code": {
-                      "version": "1.1.2",
-                      "bundled": true
-                    },
-                    "retry": {
-                      "version": "0.10.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "socks-proxy-agent": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "^4.1.0",
-                    "socks": "^1.1.10"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks": {
-                      "version": "1.1.10",
-                      "bundled": true,
-                      "requires": {
-                        "ip": "^1.1.4",
-                        "smart-buffer": "^1.0.13"
-                      },
-                      "dependencies": {
-                        "ip": {
-                          "version": "1.1.5",
-                          "bundled": true
-                        },
-                        "smart-buffer": {
-                          "version": "1.1.15",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "ssri": {
-                  "version": "5.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "^5.1.1"
-                  }
-                }
+                "agentkeepalive": "3.4.1",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.3",
+                "mississippi": "3.0.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
+              }
+            },
+            "pump": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+              }
+            },
+            "smart-buffer": {
+              "version": "1.1.15",
+              "bundled": true
+            },
+            "socks": {
+              "version": "1.1.10",
+              "bundled": true,
+              "requires": {
+                "ip": "1.1.5",
+                "smart-buffer": "1.1.15"
+              }
+            },
+            "socks-proxy-agent": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "agent-base": "4.2.0",
+                "socks": "1.1.10"
+              }
+            },
+            "ssri": {
+              "version": "5.3.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.2"
               }
             }
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "2.0.1"
           }
         },
         "npm-user-validate": {
@@ -5230,948 +3603,401 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          },
-          "dependencies": {
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-              },
-              "dependencies": {
-                "delegates": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              },
-              "dependencies": {
-                "object-assign": {
-                  "version": "4.1.1",
-                  "bundled": true
-                },
-                "signal-exit": {
-                  "version": "3.0.2",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "bundled": true
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "number-is-nan": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "wide-align": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "^1.0.2"
-                  }
-                }
-              }
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true
-            }
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "opener": {
           "version": "1.4.3",
           "bundled": true
         },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          },
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true
-            }
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "1.2.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "got": "6.7.1",
+            "registry-auth-token": "3.3.2",
+            "registry-url": "3.1.0",
+            "semver": "5.5.0"
           }
         },
         "pacote": {
-          "version": "8.1.5",
+          "version": "8.1.6",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "cacache": "^11.0.2",
-            "get-stream": "^3.0.0",
-            "glob": "^7.1.2",
-            "lru-cache": "^4.1.3",
-            "make-fetch-happen": "^4.0.1",
-            "minimatch": "^3.0.4",
-            "minipass": "^2.3.3",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "normalize-package-data": "^2.4.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.10",
-            "npm-pick-manifest": "^2.1.0",
-            "osenv": "^0.1.5",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.2",
-            "semver": "^5.5.0",
-            "ssri": "^6.0.0",
-            "tar": "4.4.1",
-            "unique-filename": "^1.1.0",
-            "which": "^1.3.0"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "make-fetch-happen": {
-              "version": "4.0.1",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^11.0.1",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.1",
-                "lru-cache": "^4.1.2",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^4.0.0",
-                "ssri": "^6.0.0"
-              },
-              "dependencies": {
-                "agentkeepalive": {
-                  "version": "3.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "humanize-ms": "^1.2.1"
-                  },
-                  "dependencies": {
-                    "humanize-ms": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "http-cache-semantics": {
-                  "version": "3.8.1",
-                  "bundled": true
-                },
-                "http-proxy-agent": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4",
-                    "debug": "3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "https-proxy-agent": {
-                  "version": "2.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "node-fetch-npm": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-better-errors": "^1.0.0",
-                    "safe-buffer": "^5.1.1"
-                  },
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "bundled": true,
-                      "requires": {
-                        "iconv-lite": "~0.4.13"
-                      },
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.23",
-                          "bundled": true,
-                          "requires": {
-                            "safer-buffer": ">= 2.1.2 < 3"
-                          },
-                          "dependencies": {
-                            "safer-buffer": {
-                              "version": "2.1.2",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "socks-proxy-agent": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "~4.2.0",
-                    "socks": "~2.2.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks": {
-                      "version": "2.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "ip": "^1.1.5",
-                        "smart-buffer": "^4.0.1"
-                      },
-                      "dependencies": {
-                        "ip": {
-                          "version": "1.1.5",
-                          "bundled": true
-                        },
-                        "smart-buffer": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "minipass": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              },
-              "dependencies": {
-                "yallist": {
-                  "version": "3.0.2",
-                  "bundled": true
-                }
-              }
-            },
-            "promise-retry": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "err-code": "^1.0.0",
-                "retry": "^0.10.0"
-              },
-              "dependencies": {
-                "err-code": {
-                  "version": "1.1.2",
-                  "bundled": true
-                },
-                "retry": {
-                  "version": "0.10.1",
-                  "bundled": true
-                }
-              }
-            },
-            "protoduck": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "genfun": "^4.0.1"
-              },
-              "dependencies": {
-                "genfun": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            }
+            "bluebird": "3.5.1",
+            "cacache": "11.0.2",
+            "get-stream": "3.0.0",
+            "glob": "7.1.2",
+            "lru-cache": "4.1.3",
+            "make-fetch-happen": "4.0.1",
+            "minimatch": "3.0.4",
+            "minipass": "2.3.3",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npm-packlist": "1.1.10",
+            "npm-pick-manifest": "2.1.0",
+            "osenv": "0.1.5",
+            "promise-inflight": "1.0.1",
+            "promise-retry": "1.1.1",
+            "protoduck": "5.0.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "ssri": "6.0.0",
+            "tar": "4.4.4",
+            "unique-filename": "1.1.0",
+            "which": "1.3.1"
           }
+        },
+        "parallel-transform": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "cyclist": "0.2.2",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
         },
         "path-is-inside": {
           "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
           "bundled": true
         },
         "promise-inflight": {
           "version": "1.0.1",
           "bundled": true
         },
+        "promise-retry": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "err-code": "1.1.2",
+            "retry": "0.10.1"
+          },
+          "dependencies": {
+            "retry": {
+              "version": "0.10.1",
+              "bundled": true
+            }
+          }
+        },
+        "promzard": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "read": "1.0.7"
+          }
+        },
+        "proto-list": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "protoduck": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "genfun": "4.0.1"
+          }
+        },
+        "prr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "pump": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        },
+        "pumpify": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "duplexify": "3.6.0",
+            "inherits": "2.0.3",
+            "pump": "2.0.1"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+              }
+            }
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
         "qrcode-terminal": {
           "version": "0.12.0",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.4.0",
           "bundled": true
         },
         "query-string": {
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "decode-uri-component": "^0.2.0",
-            "strict-uri-encode": "^2.0.0"
-          },
-          "dependencies": {
-            "decode-uri-component": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "strict-uri-encode": {
-              "version": "2.0.0",
-              "bundled": true
-            }
+            "decode-uri-component": "0.2.0",
+            "strict-uri-encode": "2.0.0"
           }
         },
         "qw": {
           "version": "1.0.1",
           "bundled": true
         },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
         "read": {
           "version": "1.0.7",
           "bundled": true,
           "requires": {
-            "mute-stream": "~0.0.4"
-          },
-          "dependencies": {
-            "mute-stream": {
-              "version": "0.0.7",
-              "bundled": true
-            }
+            "mute-stream": "0.0.7"
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2"
+            "graceful-fs": "4.1.11"
           }
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "graceful-fs": "^4.1.2",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "slide": "~1.1.3",
-            "util-extend": "^1.0.1"
-          },
-          "dependencies": {
-            "util-extend": {
-              "version": "1.0.3",
-              "bundled": true
-            }
+            "debuglog": "1.0.1",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "util-extend": "1.0.3"
           }
         },
         "read-package-json": {
           "version": "2.0.13",
           "bundled": true,
           "requires": {
-            "glob": "^7.1.1",
-            "graceful-fs": "^4.1.2",
-            "json-parse-better-errors": "^1.0.1",
-            "normalize-package-data": "^2.0.0",
-            "slash": "^1.0.0"
-          },
-          "dependencies": {
-            "json-parse-better-errors": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "slash": {
-              "version": "1.0.0",
-              "bundled": true
-            }
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "json-parse-better-errors": "1.0.2",
+            "normalize-package-data": "2.4.0",
+            "slash": "1.0.0"
           }
         },
         "read-package-tree": {
           "version": "5.2.1",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "once": "^1.3.0",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "once": "1.4.0",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            }
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "graceful-fs": "^4.1.2",
-            "once": "^1.3.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "4.1.11",
+            "once": "1.4.0"
+          }
+        },
+        "registry-auth-token": {
+          "version": "3.3.2",
+          "bundled": true,
+          "requires": {
+            "rc": "1.2.7",
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "rc": "1.2.7"
           }
         },
         "request": {
-          "version": "2.86.0",
+          "version": "2.81.0",
           "bundled": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "hawk": "~6.0.2",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
-          },
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.7.0",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "~1.0.0"
-              },
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.2",
-              "bundled": true,
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
-              },
-              "dependencies": {
-                "asynckit": {
-                  "version": "0.4.0",
-                  "bundled": true
-                }
-              }
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
-              },
-              "dependencies": {
-                "ajv": {
-                  "version": "5.5.2",
-                  "bundled": true,
-                  "requires": {
-                    "co": "^4.6.0",
-                    "fast-deep-equal": "^1.0.0",
-                    "fast-json-stable-stringify": "^2.0.0",
-                    "json-schema-traverse": "^0.3.0"
-                  },
-                  "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
-                      "bundled": true
-                    },
-                    "fast-deep-equal": {
-                      "version": "1.1.0",
-                      "bundled": true
-                    },
-                    "fast-json-stable-stringify": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    },
-                    "json-schema-traverse": {
-                      "version": "0.3.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "har-schema": {
-                  "version": "2.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.x.x",
-                "cryptiles": "3.x.x",
-                "hoek": "4.x.x",
-                "sntp": "2.x.x"
-              },
-              "dependencies": {
-                "boom": {
-                  "version": "4.3.1",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.x.x"
-                  }
-                },
-                "cryptiles": {
-                  "version": "3.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "boom": "5.x.x"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "5.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "hoek": "4.x.x"
-                      }
-                    }
-                  }
-                },
-                "hoek": {
-                  "version": "4.2.1",
-                  "bundled": true
-                },
-                "sntp": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.x.x"
-                  }
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "jsprim": {
-                  "version": "1.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "extsprintf": "1.3.0",
-                    "json-schema": "0.2.3",
-                    "verror": "1.10.0"
-                  },
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.3.0",
-                      "bundled": true
-                    },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "bundled": true
-                    },
-                    "verror": {
-                      "version": "1.10.0",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "^1.0.0",
-                        "core-util-is": "1.0.2",
-                        "extsprintf": "^1.2.0"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.14.1",
-                  "bundled": true,
-                  "requires": {
-                    "asn1": "~0.2.3",
-                    "assert-plus": "^1.0.0",
-                    "bcrypt-pbkdf": "^1.0.0",
-                    "dashdash": "^1.12.0",
-                    "ecc-jsbn": "~0.1.1",
-                    "getpass": "^0.1.1",
-                    "jsbn": "~0.1.0",
-                    "tweetnacl": "~0.14.0"
-                  },
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "bundled": true
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "tweetnacl": "^0.14.3"
-                      }
-                    },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "^1.0.0"
-                      }
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "jsbn": "~0.1.0"
-                      }
-                    },
-                    "getpass": {
-                      "version": "0.1.7",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "^1.0.0"
-                      }
-                    },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.5",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.18",
-              "bundled": true,
-              "requires": {
-                "mime-db": "~1.33.0"
-              },
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.33.0",
-                  "bundled": true
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.4",
-              "bundled": true,
-              "requires": {
-                "punycode": "^1.4.1"
-              },
-              "dependencies": {
-                "punycode": {
-                  "version": "1.4.1",
-                  "bundled": true
-                }
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "^5.0.1"
-              }
-            }
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.2",
+            "stringstream": "0.0.6",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.3.2"
           }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true
         },
         "retry": {
           "version": "0.12.0",
@@ -6181,28 +4007,96 @@
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
+          }
+        },
+        "run-queue": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true
         },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
         "semver": {
           "version": "5.5.0",
+          "bundled": true
+        },
+        "semver-diff": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "semver": "5.5.0"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
           "bundled": true
         },
         "sha": {
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.3.6"
           }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
         },
         "slide": {
           "version": "1.1.6",
           "bundled": true
+        },
+        "smart-buffer": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "socks": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "ip": "1.1.5",
+            "smart-buffer": "4.0.1"
+          }
+        },
+        "socks-proxy-agent": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "agent-base": "4.2.0",
+            "socks": "2.2.0"
+          }
         },
         "sorted-object": {
           "version": "2.0.1",
@@ -6212,57 +4106,80 @@
           "version": "2.1.3",
           "bundled": true,
           "requires": {
-            "from2": "^1.3.0",
-            "stream-iterate": "^1.1.0"
+            "from2": "1.3.0",
+            "stream-iterate": "1.2.0"
           },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "~1.1.10"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.14",
-                  "bundled": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.1",
-                    "isarray": "0.0.1",
-                    "string_decoder": "~0.10.x"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "bundled": true
-                    }
-                  }
-                }
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
               }
             },
-            "stream-iterate": {
-              "version": "1.2.0",
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
               "bundled": true,
               "requires": {
-                "readable-stream": "^2.1.5",
-                "stream-shift": "^1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
               }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true
+            }
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.14.2",
+          "bundled": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.2",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "safer-buffer": "2.1.2",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
             }
           }
         },
@@ -6270,66 +4187,159 @@
           "version": "6.0.0",
           "bundled": true
         },
-        "strip-ansi": {
-          "version": "4.0.0",
+        "stream-each": {
+          "version": "1.2.2",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "end-of-stream": "1.4.1",
+            "stream-shift": "1.0.0"
+          }
+        },
+        "stream-iterate": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "2.3.6",
+            "stream-shift": "1.0.0"
+          }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
               "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
             }
           }
         },
-        "tar": {
-          "version": "4.4.1",
+        "string_decoder": {
+          "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        },
+        "tar": {
+          "version": "4.4.4",
+          "bundled": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.3",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           },
           "dependencies": {
-            "fs-minipass": {
-              "version": "1.2.5",
-              "bundled": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "minipass": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "^5.1.1",
-                "yallist": "^3.0.0"
-              }
-            },
-            "minizlib": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
             "yallist": {
               "version": "3.0.2",
               "bundled": true
             }
           }
         },
+        "term-size": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "execa": "0.7.0"
+          }
+        },
         "text-table": {
           "version": "0.2.0",
           "bundled": true
         },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true
+        },
         "tiny-relative-date": {
           "version": "1.3.0",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "typedarray": {
+          "version": "0.0.6",
           "bundled": true
         },
         "uid-number": {
@@ -6344,586 +4354,161 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "unique-slug": "^2.0.0"
-          },
-          "dependencies": {
-            "unique-slug": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "imurmurhash": "^0.1.4"
-              }
-            }
+            "unique-slug": "2.0.0"
+          }
+        },
+        "unique-slug": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "imurmurhash": "0.1.4"
+          }
+        },
+        "unique-string": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "crypto-random-string": "1.0.0"
           }
         },
         "unpipe": {
           "version": "1.0.0",
           "bundled": true
         },
+        "unzip-response": {
+          "version": "2.0.1",
+          "bundled": true
+        },
         "update-notifier": {
           "version": "2.5.0",
           "bundled": true,
           "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          },
-          "dependencies": {
-            "boxen": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "ansi-align": "^2.0.0",
-                "camelcase": "^4.0.0",
-                "chalk": "^2.0.1",
-                "cli-boxes": "^1.0.0",
-                "string-width": "^2.0.0",
-                "term-size": "^1.2.0",
-                "widest-line": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-align": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "^2.0.0"
-                  }
-                },
-                "camelcase": {
-                  "version": "4.1.0",
-                  "bundled": true
-                },
-                "cli-boxes": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "^2.0.0",
-                    "strip-ansi": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "term-size": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "execa": "^0.7.0"
-                  },
-                  "dependencies": {
-                    "execa": {
-                      "version": "0.7.0",
-                      "bundled": true,
-                      "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "cross-spawn": {
-                          "version": "5.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "lru-cache": "^4.0.1",
-                            "shebang-command": "^1.2.0",
-                            "which": "^1.2.9"
-                          },
-                          "dependencies": {
-                            "shebang-command": {
-                              "version": "1.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "shebang-regex": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "shebang-regex": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "npm-run-path": {
-                          "version": "2.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "path-key": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "path-key": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "p-finally": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "signal-exit": {
-                          "version": "3.0.2",
-                          "bundled": true
-                        },
-                        "strip-eof": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "widest-line": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "^2.1.1"
-                  }
-                }
-              }
-            },
-            "chalk": {
-              "version": "2.4.1",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "3.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "color-convert": "^1.9.0"
-                  },
-                  "dependencies": {
-                    "color-convert": {
-                      "version": "1.9.1",
-                      "bundled": true,
-                      "requires": {
-                        "color-name": "^1.1.1"
-                      },
-                      "dependencies": {
-                        "color-name": {
-                          "version": "1.1.3",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "bundled": true
-                },
-                "supports-color": {
-                  "version": "5.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "3.0.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "configstore": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "dot-prop": "^4.1.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^1.0.0",
-                "unique-string": "^1.0.0",
-                "write-file-atomic": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
-              },
-              "dependencies": {
-                "dot-prop": {
-                  "version": "4.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "is-obj": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "is-obj": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "make-dir": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "pify": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "pify": {
-                      "version": "3.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "unique-string": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "crypto-random-string": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "crypto-random-string": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "import-lazy": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "is-ci": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "ci-info": "^1.0.0"
-              },
-              "dependencies": {
-                "ci-info": {
-                  "version": "1.1.3",
-                  "bundled": true
-                }
-              }
-            },
-            "is-installed-globally": {
-              "version": "0.1.0",
-              "bundled": true,
-              "requires": {
-                "global-dirs": "^0.1.0",
-                "is-path-inside": "^1.0.0"
-              },
-              "dependencies": {
-                "global-dirs": {
-                  "version": "0.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "ini": "^1.3.4"
-                  }
-                },
-                "is-path-inside": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "path-is-inside": "^1.0.1"
-                  }
-                }
-              }
-            },
-            "is-npm": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "latest-version": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "package-json": "^4.0.0"
-              },
-              "dependencies": {
-                "package-json": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "got": "^6.7.1",
-                    "registry-auth-token": "^3.0.1",
-                    "registry-url": "^3.0.3",
-                    "semver": "^5.1.0"
-                  },
-                  "dependencies": {
-                    "got": {
-                      "version": "6.7.1",
-                      "bundled": true,
-                      "requires": {
-                        "create-error-class": "^3.0.0",
-                        "duplexer3": "^0.1.4",
-                        "get-stream": "^3.0.0",
-                        "is-redirect": "^1.0.0",
-                        "is-retry-allowed": "^1.0.0",
-                        "is-stream": "^1.0.0",
-                        "lowercase-keys": "^1.0.0",
-                        "safe-buffer": "^5.0.1",
-                        "timed-out": "^4.0.0",
-                        "unzip-response": "^2.0.1",
-                        "url-parse-lax": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "create-error-class": {
-                          "version": "3.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "capture-stack-trace": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "capture-stack-trace": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexer3": {
-                          "version": "0.1.4",
-                          "bundled": true
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-redirect": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "is-retry-allowed": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "lowercase-keys": {
-                          "version": "1.0.1",
-                          "bundled": true
-                        },
-                        "timed-out": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        },
-                        "unzip-response": {
-                          "version": "2.0.1",
-                          "bundled": true
-                        },
-                        "url-parse-lax": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "prepend-http": "^1.0.1"
-                          },
-                          "dependencies": {
-                            "prepend-http": {
-                              "version": "1.0.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-auth-token": {
-                      "version": "3.3.2",
-                      "bundled": true,
-                      "requires": {
-                        "rc": "^1.1.6",
-                        "safe-buffer": "^5.0.1"
-                      },
-                      "dependencies": {
-                        "rc": {
-                          "version": "1.2.7",
-                          "bundled": true,
-                          "requires": {
-                            "deep-extend": "^0.5.1",
-                            "ini": "~1.3.0",
-                            "minimist": "^1.2.0",
-                            "strip-json-comments": "~2.0.1"
-                          },
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "0.5.1",
-                              "bundled": true
-                            },
-                            "minimist": {
-                              "version": "1.2.0",
-                              "bundled": true
-                            },
-                            "strip-json-comments": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-url": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "rc": "^1.0.1"
-                      },
-                      "dependencies": {
-                        "rc": {
-                          "version": "1.2.7",
-                          "bundled": true,
-                          "requires": {
-                            "deep-extend": "^0.5.1",
-                            "ini": "~1.3.0",
-                            "minimist": "^1.2.0",
-                            "strip-json-comments": "~2.0.1"
-                          },
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "0.5.1",
-                              "bundled": true
-                            },
-                            "minimist": {
-                              "version": "1.2.0",
-                              "bundled": true
-                            },
-                            "strip-json-comments": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "semver-diff": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "semver": "^5.0.3"
-              }
-            },
-            "xdg-basedir": {
-              "version": "3.0.0",
-              "bundled": true
-            }
+            "boxen": "1.3.0",
+            "chalk": "2.4.1",
+            "configstore": "3.1.2",
+            "import-lazy": "2.1.0",
+            "is-ci": "1.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
           }
         },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "1.0.4"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "util-extend": {
+          "version": "1.0.3",
+          "bundled": true
+        },
         "uuid": {
-          "version": "3.2.1",
+          "version": "3.3.2",
           "bundled": true
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
           "bundled": true,
           "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
-          },
-          "dependencies": {
-            "spdx-correct": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-              },
-              "dependencies": {
-                "spdx-license-ids": {
-                  "version": "3.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "spdx-expression-parse": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-              },
-              "dependencies": {
-                "spdx-exceptions": {
-                  "version": "2.1.0",
-                  "bundled": true
-                },
-                "spdx-license-ids": {
-                  "version": "3.0.0",
-                  "bundled": true
-                }
-              }
-            }
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
           }
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "builtins": "^1.0.3"
+            "builtins": "1.0.3"
+          }
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
           },
           "dependencies": {
-            "builtins": {
-              "version": "1.0.3",
+            "assert-plus": {
+              "version": "1.0.0",
               "bundled": true
             }
           }
         },
-        "which": {
-          "version": "1.3.0",
+        "wcwidth": {
+          "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "defaults": "1.0.3"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2"
           },
           "dependencies": {
-            "isexe": {
-              "version": "2.0.0",
-              "bundled": true
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
             }
+          }
+        },
+        "widest-line": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "2.1.1"
           }
         },
         "worker-farm": {
           "version": "1.6.0",
           "bundled": true,
           "requires": {
-            "errno": "~0.1.7"
+            "errno": "0.1.7"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           },
           "dependencies": {
-            "errno": {
-              "version": "0.1.7",
+            "string-width": {
+              "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "prr": "~1.0.1"
-              },
-              "dependencies": {
-                "prr": {
-                  "version": "1.0.1",
-                  "bundled": true
-                }
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -6936,15 +4521,56 @@
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "11.0.0",
+          "bundled": true,
+          "requires": {
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           },
           "dependencies": {
-            "signal-exit": {
-              "version": "3.0.2",
+            "y18n": {
+              "version": "3.2.1",
               "bundled": true
             }
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "bundled": true,
+          "requires": {
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -6955,7 +4581,7 @@
       "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
       "dev": true,
       "requires": {
-        "path-key": "^1.0.0"
+        "path-key": "1.0.0"
       }
     },
     "npmlog": {
@@ -6963,10 +4589,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
       "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM=",
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.6.0",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.6.0",
+        "set-blocking": "2.0.0"
       }
     },
     "number-is-nan": {
@@ -6989,7 +4615,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "oniguruma": {
@@ -6997,7 +4623,7 @@
       "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-6.2.1.tgz",
       "integrity": "sha1-pQ7mlkKEStHSUmhaqxhxcbBuzgQ=",
       "requires": {
-        "nan": "^2.0.9"
+        "nan": "2.8.0"
       }
     },
     "open": {
@@ -7010,7 +4636,7 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.4.0.tgz",
       "integrity": "sha1-y47Dfy/jqphky2eidSUOfhliCiU=",
       "requires": {
-        "wordwrap": "~0.0.2"
+        "wordwrap": "0.0.2"
       }
     },
     "os-homedir": {
@@ -7023,7 +4649,7 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -7036,8 +4662,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "parse-json": {
@@ -7046,7 +4672,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "path-array": {
@@ -7054,7 +4680,7 @@
       "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
       "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
       "requires": {
-        "array-index": "^1.0.0"
+        "array-index": "1.0.0"
       }
     },
     "path-exists": {
@@ -7063,7 +4689,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -7083,9 +4709,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "pause": {
@@ -7117,15 +4743,14 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "plist": {
       "version": "git+https://github.com/nathansobo/node-plist.git#bd3a93387f1d4b2cff819b200870d35465796e77",
-      "from": "git+https://github.com/nathansobo/node-plist.git",
       "requires": {
-        "xmlbuilder": "0.4.x",
-        "xmldom": "0.1.x"
+        "xmlbuilder": "0.4.3",
+        "xmldom": "0.1.27"
       }
     },
     "process-nextick-args": {
@@ -7138,8 +4763,8 @@
       "resolved": "https://registry.npmjs.org/property-accessors/-/property-accessors-1.1.3.tgz",
       "integrity": "sha1-Hd6EAkYxhlkJ7zBwM2VoDF+SixU=",
       "requires": {
-        "es6-weak-map": "^0.1.2",
-        "mixto": "1.x"
+        "es6-weak-map": "0.1.4",
+        "mixto": "1.0.0"
       }
     },
     "punycode": {
@@ -7168,7 +4793,7 @@
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "requires": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "0.0.7"
       }
     },
     "read-pkg": {
@@ -7177,9 +4802,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -7188,8 +4813,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
@@ -7197,10 +4822,10 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
         "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "string_decoder": "0.10.31"
       }
     },
     "redent": {
@@ -7209,8 +4834,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "repeating": {
@@ -7219,7 +4844,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "request": {
@@ -7227,28 +4852,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
       }
     },
     "requirejs": {
@@ -7268,7 +4893,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       },
       "dependencies": {
         "glob": {
@@ -7276,12 +4901,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -7296,9 +4921,9 @@
       "resolved": "https://registry.npmjs.org/season/-/season-6.0.2.tgz",
       "integrity": "sha1-naWPsd3SSCTXYhstxjpxI7UCF7Y=",
       "requires": {
-        "cson-parser": "^1.3.0",
-        "fs-plus": "^3.0.0",
-        "yargs": "^3.23.0"
+        "cson-parser": "1.3.5",
+        "fs-plus": "3.0.1",
+        "yargs": "3.32.0"
       },
       "dependencies": {
         "async": {
@@ -7316,7 +4941,7 @@
           "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
           "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
           "requires": {
-            "coffee-script": "^1.10.0"
+            "coffee-script": "1.12.7"
           }
         },
         "fs-plus": {
@@ -7324,10 +4949,10 @@
           "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
           "integrity": "sha1-VMFpxA4ohKZtNSeA0Y3TH5HToQ0=",
           "requires": {
-            "async": "^1.5.2",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.2",
-            "underscore-plus": "1.x"
+            "async": "1.5.2",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "underscore-plus": "1.6.6"
           }
         }
       }
@@ -7343,7 +4968,7 @@
       "integrity": "sha1-z7COvTzsm3/Bo32f+eh1qXHPRkA=",
       "dev": true,
       "requires": {
-        "debug": "*",
+        "debug": "2.6.9",
         "fresh": "0.1.0",
         "mime": "1.2.6",
         "range-parser": "0.0.4"
@@ -7378,7 +5003,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.0"
       }
     },
     "source-map": {
@@ -7387,7 +5012,7 @@
       "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
       "dev": true,
       "requires": {
-        "amdefine": ">=0.0.4"
+        "amdefine": "1.0.1"
       }
     },
     "spdx-correct": {
@@ -7396,7 +5021,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-license-ids": "1.2.2"
       }
     },
     "spdx-expression-parse": {
@@ -7422,14 +5047,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       }
     },
     "string-width": {
@@ -7437,9 +5062,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -7457,7 +5082,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -7466,7 +5091,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-indent": {
@@ -7475,7 +5100,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -7495,9 +5120,9 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
       }
     },
     "temp": {
@@ -7505,8 +5130,8 @@
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "requires": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.2.6"
+        "os-tmpdir": "1.0.2",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "rimraf": {
@@ -7527,7 +5152,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "touch": {
@@ -7535,7 +5160,7 @@
       "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
       "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
       "requires": {
-        "nopt": "~1.0.10"
+        "nopt": "1.0.10"
       },
       "dependencies": {
         "nopt": {
@@ -7543,7 +5168,7 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "requires": {
-            "abbrev": "1"
+            "abbrev": "1.1.1"
           }
         }
       }
@@ -7553,7 +5178,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "traverse": {
@@ -7572,7 +5197,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "tweetnacl": {
@@ -7591,7 +5216,7 @@
       "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz",
       "integrity": "sha1-ZezeG9xEGjXYnmUP1w3PE65Dmn0=",
       "requires": {
-        "underscore": "~1.6.0"
+        "underscore": "1.6.0"
       }
     },
     "underscore.string": {
@@ -7622,8 +5247,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
       }
     },
     "verror": {
@@ -7631,9 +5256,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "walkdir": {
@@ -7647,7 +5272,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "wide-align": {
@@ -7655,7 +5280,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
-        "string-width": "^1.0.2"
+        "string-width": "1.0.2"
       }
     },
     "window-size": {
@@ -7673,8 +5298,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
@@ -7707,13 +5332,13 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
+        "camelcase": "2.1.1",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "os-locale": "1.4.0",
+        "string-width": "1.0.2",
+        "window-size": "0.1.4",
+        "y18n": "3.2.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mv": "2.0.0",
     "ncp": "~0.5.1",
     "node-gyp": "3.4.0",
-    "npm": "6.1.0",
+    "npm": "6.2.0",
     "open": "0.0.4",
     "plist": "git+https://github.com/nathansobo/node-plist.git",
     "q": "~0.9.7",


### PR DESCRIPTION
### Description of the Change

This change updates `apm` to use `npm` 6.2.0 to benefit from some [major dependency restructuring and flattening](https://github.com/nodejs/node/pull/21592) that shaved about **60** characters off of `npm`'s directory tree paths, specifically to aid with installing Node.js on Windows.

Since we've been fighting with "path too long" errors with Squirrel for a long time, this new version of `npm` is a welcome relief and a path forward to finally deliver side-by-side Atom release channel installations on Windows.

### Alternate Designs

I also tried running `npm dedupe` in Atom's `apm` folder in various different ways and it either broke `apm`, broke Atom's app packaging, or had no real effect.  Updating to `npm` 6.2.0 is the only thing that brought results.

I also tried updating to `npm` 6.3.0 but ran into some issues with `apm` after doing that, so it's probably better to hold off for now.

### Benefits

- Shorter Atom installation paths on Windows
- One step closer to having side-by-side installation channels on Windows https://github.com/atom/atom/issues/9247

### Possible Drawbacks

Minor bugs introduced by 6.2?  So far everything seems solid.

### Applicable Issues

- https://github.com/atom/atom/issues/9247