### PR TITLE
Improve spec stability

### DIFF
--- a/spec/docs-spec.coffee
+++ b/spec/docs-spec.coffee
@@ -16,13 +16,18 @@ describe 'apm docs', ->
       response.sendFile path.join(__dirname, 'fixtures', 'wrap-guide.json')
     app.get '/install', (request, response) ->
       response.sendFile path.join(__dirname, 'fixtures', 'install.json')
-    server =  http.createServer(app)
-    server.listen(3000)
+    server = http.createServer(app)
 
-    process.env.ATOM_PACKAGES_URL = "http://localhost:3000"
+    live = false
+    server.listen 3000, '127.0.0.1', ->
+      process.env.ATOM_PACKAGES_URL = "http://localhost:3000"
+      live = true
+    waitsFor -> live
 
   afterEach ->
-    server.close()
+    done = false
+    server.close -> done = true
+    waitsFor -> done
 
   it 'logs an error if the package has no URL', ->
     callback = jasmine.createSpy('callback')

--- a/spec/featured-spec.coffee
+++ b/spec/featured-spec.coffee
@@ -15,14 +15,18 @@ describe 'apm featured', ->
       response.sendFile path.join(__dirname, 'fixtures', 'packages.json')
     app.get '/themes/featured', (request, response) ->
       response.sendFile path.join(__dirname, 'fixtures', 'themes.json')
+    server = http.createServer(app)
 
-    server =  http.createServer(app)
-    server.listen(3000)
-
-    process.env.ATOM_API_URL = "http://localhost:3000"
+    live = false
+    server.listen 3000, '127.0.0.1', ->
+      process.env.ATOM_API_URL = "http://localhost:3000"
+      live = true
+    waitsFor -> live
 
   afterEach ->
-    server.close()
+    done = false
+    server.close -> done = true
+    waitsFor -> done
 
   it 'lists the featured packages and themes', ->
     callback = jasmine.createSpy('callback')

--- a/spec/publish-spec.coffee
+++ b/spec/publish-spec.coffee
@@ -14,15 +14,20 @@ describe 'apm publish', ->
 
     app = express()
     server =  http.createServer(app)
-    server.listen(3000)
 
-    atomHome = temp.mkdirSync('apm-home-dir-')
-    process.env.ATOM_HOME = atomHome
-    process.env.ATOM_API_URL = "http://localhost:3000/api"
-    process.env.ATOM_RESOURCE_PATH = temp.mkdirSync('atom-resource-path-')
+    live = false
+    server.listen 3000, '127.0.0.1', ->
+      atomHome = temp.mkdirSync('apm-home-dir-')
+      process.env.ATOM_HOME = atomHome
+      process.env.ATOM_API_URL = "http://localhost:3000/api"
+      process.env.ATOM_RESOURCE_PATH = temp.mkdirSync('atom-resource-path-')
+      live = true
+    waitsFor -> live
 
   afterEach ->
-    server.close()
+    done = false
+    server.close -> done = true
+    waitsFor -> done
 
   it "validates the package's package.json file", ->
     packageToPublish = temp.mkdirSync('apm-test-package-')

--- a/spec/rebuild-spec.coffee
+++ b/spec/rebuild-spec.coffee
@@ -24,22 +24,28 @@ describe 'apm rebuild', ->
     app.get '/node/v0.10.3/SHASUMS256.txt', (request, response) ->
       response.sendFile path.join(__dirname, 'fixtures', 'SHASUMS256.txt')
 
-    server =  http.createServer(app)
-    server.listen(3000)
+    server = http.createServer(app)
 
-    atomHome = temp.mkdirSync('apm-home-dir-')
-    process.env.ATOM_HOME = atomHome
-    process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
-    process.env.ATOM_PACKAGES_URL = "http://localhost:3000/packages"
-    process.env.ATOM_ELECTRON_VERSION = 'v0.10.3'
-    process.env.ATOM_RESOURCE_PATH = temp.mkdirSync('atom-resource-path-')
+    live = false
+    server.listen 3000, '127.0.0.1', ->
+      atomHome = temp.mkdirSync('apm-home-dir-')
+      process.env.ATOM_HOME = atomHome
+      process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
+      process.env.ATOM_PACKAGES_URL = "http://localhost:3000/packages"
+      process.env.ATOM_ELECTRON_VERSION = 'v0.10.3'
+      process.env.ATOM_RESOURCE_PATH = temp.mkdirSync('atom-resource-path-')
 
-    originalPathEnv = process.env.PATH
-    process.env.PATH = ""
+      originalPathEnv = process.env.PATH
+      process.env.PATH = ""
+      live = true
+    waitsFor -> live
 
   afterEach ->
-    server.close()
     process.env.PATH = originalPathEnv
+
+    done = false
+    server.close -> done = true
+    waitsFor -> done
 
   it "rebuilds all modules when no module names are specified", ->
     packageToRebuild = path.join(__dirname, 'fixtures/package-with-native-deps')

--- a/spec/search-spec.coffee
+++ b/spec/search-spec.coffee
@@ -13,13 +13,18 @@ describe 'apm search', ->
     app = express()
     app.get '/search', (request, response) ->
       response.sendFile path.join(__dirname, 'fixtures', 'search.json')
-    server =  http.createServer(app)
-    server.listen(3000)
+    server = http.createServer(app)
 
-    process.env.ATOM_PACKAGES_URL = "http://localhost:3000"
+    live = false
+    server.listen 3000, '127.0.0.1', ->
+      process.env.ATOM_PACKAGES_URL = "http://localhost:3000"
+      live = true
+    waitsFor -> live
 
   afterEach ->
-    server.close()
+    done = false
+    server.close -> done = true
+    waitsFor -> done
 
   it 'lists the matching packages and excludes deprecated packages', ->
     callback = jasmine.createSpy('callback')

--- a/spec/unpublish-spec.coffee
+++ b/spec/unpublish-spec.coffee
@@ -24,14 +24,19 @@ describe 'apm unpublish', ->
       unpublishVersionCallback()
       response.status(204).send(204)
 
-    server =  http.createServer(app)
-    server.listen(3000)
+    server = http.createServer(app)
 
-    process.env.ATOM_HOME = temp.mkdirSync('apm-home-dir-')
-    process.env.ATOM_API_URL = "http://localhost:3000"
+    live = false
+    server.listen 3000, '127.0.0.1', ->
+      process.env.ATOM_HOME = temp.mkdirSync('apm-home-dir-')
+      process.env.ATOM_API_URL = "http://localhost:3000"
+      live = true
+    waitsFor -> live
 
   afterEach ->
-    server.close()
+    done = false
+    server.close -> done = true
+    waitsFor -> done
 
   describe "when no version is specified", ->
     it 'unpublishes the package', ->

--- a/spec/upgrade-spec.coffee
+++ b/spec/upgrade-spec.coffee
@@ -30,21 +30,26 @@ describe "apm upgrade", ->
     app.get '/packages/different-repo', (request, response) ->
       response.sendFile path.join(__dirname, 'fixtures', 'upgrade-different-repo.json')
     server =  http.createServer(app)
-    server.listen(3000)
 
-    atomHome = temp.mkdirSync('apm-home-dir-')
-    atomApp = temp.mkdirSync('apm-app-dir-')
-    packagesDir = path.join(atomHome, 'packages')
-    process.env.ATOM_HOME = atomHome
-    process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
-    process.env.ATOM_PACKAGES_URL = "http://localhost:3000/packages"
-    process.env.ATOM_ELECTRON_VERSION = 'v0.10.3'
-    process.env.ATOM_RESOURCE_PATH = atomApp
+    live = false
+    server.listen 3000, '127.0.0.1', ->
+      atomHome = temp.mkdirSync('apm-home-dir-')
+      atomApp = temp.mkdirSync('apm-app-dir-')
+      packagesDir = path.join(atomHome, 'packages')
+      process.env.ATOM_HOME = atomHome
+      process.env.ATOM_ELECTRON_URL = "http://localhost:3000/node"
+      process.env.ATOM_PACKAGES_URL = "http://localhost:3000/packages"
+      process.env.ATOM_ELECTRON_VERSION = 'v0.10.3'
+      process.env.ATOM_RESOURCE_PATH = atomApp
 
-    fs.writeFileSync(path.join(atomApp, 'package.json'), JSON.stringify(version: '0.10.0'))
+      fs.writeFileSync(path.join(atomApp, 'package.json'), JSON.stringify(version: '0.10.0'))
+      live = true
+    waitsFor -> live
 
   afterEach ->
-    server.close()
+    done = false
+    server.close -> done = true
+    waitsFor -> done
 
   it "does not display updates for unpublished packages", ->
     fs.writeFileSync(path.join(packagesDir, 'not-published', 'package.json'), JSON.stringify({name: 'not-published', version: '1.0', repository: 'https://github.com/a/b'}))

--- a/spec/view-spec.coffee
+++ b/spec/view-spec.coffee
@@ -14,12 +14,17 @@ describe 'apm view', ->
     app.get '/wrap-guide', (request, response) ->
       response.sendFile path.join(__dirname, 'fixtures', 'wrap-guide.json')
     server =  http.createServer(app)
-    server.listen(3000)
 
-    process.env.ATOM_PACKAGES_URL = "http://localhost:3000"
+    live = false
+    server.listen 3000, '127.0.0.1', ->
+      process.env.ATOM_PACKAGES_URL = "http://localhost:3000"
+      live = true
+    waitsFor -> live
 
   afterEach ->
-    server.close()
+    done = false
+    server.close -> done = true
+    waitsFor -> done
 
   it 'displays information about the package', ->
     callback = jasmine.createSpy('callback')


### PR DESCRIPTION
A bunch of apm's specs create an express.js server to mock the npm and atom.io APIs. However, both `server.listen()` and `server.close()` are asynchronous, and if one spec's test is not closed before the next starts, the setup for the next fails with an `EADDRINUSE` error. It tends not to happen because of accidental ordering of asynchronous ticks... but if you anger the async gods, it can easily cause spurious failures.

I'm preventing this from happening by using a callback and a `waitsFor` guard in each `beforeEach` and `afterEach` clause.