### PR TITLE
Restore npm rebuild call

### DIFF
--- a/script/postinstall.sh
+++ b/script/postinstall.sh
@@ -5,16 +5,9 @@ set -e
 echo ">> Downloading bundled Node"
 node script/download-node.js
 
-HOST_MODULE_VERSION=$(node -p 'process.versions.modules')
-BUNDLED_MODULE_VERSION=$(./bin/node -p 'process.versions.modules')
-
 echo
-if [ "${HOST_MODULE_VERSION}" != "${BUNDLED_MODULE_VERSION}" ]; then
-  echo ">> Rebuilding apm dependencies with bundled Node $(./bin/node -p "process.version + ' ' + process.arch")"
-  ./bin/npm rebuild
-else
-  echo ">> No need to rebuild dependencies"
-fi
+echo ">> Rebuilding apm dependencies with bundled Node $(./bin/node -p "process.version + ' ' + process.arch")"
+./bin/npm rebuild
 
 echo
 if [ -z "${NO_APM_DEDUPE}" ]; then


### PR DESCRIPTION
Reverts part of #808.

Native modules built on Windows with apm 2.1.1 are failing to initialize properly with a curious error:

```
A dynamic link library (DLL) initialization routine failed.
\\?\C:\projects\github\node_modules\keytar\build\Release\keytar.node
```

The only relevant change in apm 2.1.0 is #808, so it must be necessary to rebuild native modules on Windows even if the module version is unchanged... ? I have no idea why this would make a difference.