### PR TITLE
Avoid duplicate installs of repo-local bundled packages in package.json

### DIFF
--- a/src/install.coffee
+++ b/src/install.coffee
@@ -347,7 +347,7 @@ class Install extends Command
     for name, version of @getPackageDependencies()
       do (name, version) =>
         commands.push (next) =>
-          if version.match(@repoLocalPackagePathRegex)
+          if @repoLocalPackagePathRegex.test(version)
             @installLocalPackage(name, version, options, next)
           else
             @installRegisteredPackage({name, version}, options, next)
@@ -369,8 +369,8 @@ class Install extends Command
       metadata = fs.readFileSync('package.json', 'utf8')
       {packageDependencies, dependencies} = JSON.parse(metadata) ? {}
 
-      return {} if not packageDependencies
-      return packageDependencies if not dependencies
+      return {} unless packageDependencies
+      return packageDependencies unless dependencies
 
       # This code filters out any `packageDependencies` that have an equivalent
       # normalized repo-local package path entry in the `dependencies` section of

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -27,6 +27,7 @@ class Install extends Command
     @atomPackagesDirectory = path.join(@atomDirectory, 'packages')
     @atomNodeDirectory = path.join(@atomDirectory, '.node-gyp')
     @atomNpmPath = require.resolve('npm/bin/npm-cli')
+    @repoLocalPackagePathRegex = /^file:(?!\/\/)(.*)/
 
   parseOptions: (argv) ->
     options = yargs(argv).wrap(100)
@@ -346,7 +347,7 @@ class Install extends Command
     for name, version of @getPackageDependencies()
       do (name, version) =>
         commands.push (next) =>
-          if version.startsWith('file:.')
+          if version.match(@repoLocalPackagePathRegex)
             @installLocalPackage(name, version, options, next)
           else
             @installRegisteredPackage({name, version}, options, next)
@@ -366,10 +367,32 @@ class Install extends Command
   getPackageDependencies: ->
     try
       metadata = fs.readFileSync('package.json', 'utf8')
-      {packageDependencies} = JSON.parse(metadata) ? {}
-      packageDependencies ? {}
+      {packageDependencies, dependencies} = JSON.parse(metadata) ? {}
+
+      return {} if not packageDependencies
+      return packageDependencies if not dependencies
+
+      # This code filters out any `packageDependencies` that have an equivalent
+      # normalized repo-local package path entry in the `dependencies` section of
+      # `package.json`.  Versioned `packageDependencies` are always returned.
+      filteredPackages = {}
+      for packageName, packageSpec of packageDependencies
+        dependencyPath = @getRepoLocalPackagePath(dependencies[packageName])
+        packageDependencyPath = @getRepoLocalPackagePath(packageSpec)
+        unless packageDependencyPath and dependencyPath is packageDependencyPath
+          filteredPackages[packageName] = packageSpec
+
+      filteredPackages
     catch error
       {}
+
+  getRepoLocalPackagePath: (packageSpec) ->
+    return undefined if not packageSpec
+    repoLocalPackageMatch = packageSpec.match(@repoLocalPackagePathRegex)
+    if repoLocalPackageMatch
+      path.normalize(repoLocalPackageMatch[1])
+    else
+      undefined
 
   createAtomDirectories: ->
     fs.makeTreeSync(@atomDirectory)


### PR DESCRIPTION
### Description of the Change

This change optimizes the installation of repo-local `packageDependencies` by ensuring that they don't get installed a second time when running `apm install`.  Since `npm` adds the same repo-local package path to the `dependencies` section after it has been installed via the `packageDependencies` section, `npm` will then install it during the initial `npm install` phase that `apm` runs.

`apm` had been running a second install of all repo-local packages, ignoring the fact that `npm` had already installed them.  This has contributed to gradually increasing build times in the Atom repo.

This changes makes `apm`'s installation of `packageDependendencies` aware of duplicate repo-local package entries in the `dependencies` section so that they don't get installed a second time unnecessarily.

Thanks to @annthurium for pairing on this!

### Alternate Designs

None that I can think of, but would love to get feedback on what I could do differently!

### Benefits

- Faster Atom builds
- Less unnecessary runs of `npm install` on repo-local packages

### Possible Drawbacks

None that I'm aware of.

### Verification Process

- [x] Added test cases to verify the different types of `packageDependencies` that we want to include or exclude from the installation step
- [x] Ran an Atom build locally with the update `apm` and verified that the repo-local packages do indeed get installed in `node_modules` even when `getPackageDependencies` excludes them

### Applicable Issues

None.
