### PR TITLE
Ensure postinstall script is executable

### DIFF
--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -1,12 +1,19 @@
-var path = require('path')
+#!/usr/bin/env node
+
 var cp = require('child_process')
+var fs = require('fs')
+var path = require('path')
 
 var script = path.join(__dirname, 'postinstall')
-if (process.platform.indexOf('win') === 0) {
+if (process.platform === 'win32') {
   script += '.cmd'
 } else {
   script += '.sh'
 }
+
+// Read + execute permission
+fs.chmodSync(script, fs.constants.S_IRUSR | fs.constants.S_IXUSR)
+
 var child = cp.spawn(script, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true })
 child.stderr.pipe(process.stderr)
 child.stdout.pipe(process.stdout)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

We need to make sure that the postinstall script is executable for installation not to fail. However, previously, when publishing apm on a Windows machine, `postinstall.sh` would lose execute permissions. This fixes that by chmod'ing the file right before running it to ensure the correct permissions.

### Alternate Designs

None.

### Benefits

apm can now be published on Windows without downstream installation failures.

### Possible Drawbacks

None.

### Verification Process

Well, I suppose we'll find out if this works when I publish a new release.