### PR TITLE
Fix test that was using async copy without waiting for it to finish

### DIFF
--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -534,9 +534,12 @@ describe 'apm install', ->
       npmNodeModules = fs.realpathSync(path.join(__dirname, '..', 'node_modules', 'npm', 'node_modules'))
 
       beforeEach ->
-        fs.cp path.join(npmNodeModules, 'node-gyp'), path.join(npmNodeModules, 'with a space')
+        fs.copySync path.join(npmNodeModules, 'node-gyp'), path.join(npmNodeModules, 'with a space')
         process.env.npm_config_node_gyp = path.join(npmNodeModules, 'with a space', 'bin', 'node-gyp.js')
         process.env.ATOM_NODE_GYP_PATH = path.join(npmNodeModules, 'with a space', 'bin', 'node-gyp.js')
+
+        # Read + execute permission
+        fs.chmodSync(process.env.npm_config_node_gyp, fs.constants.S_IRUSR | fs.constants.S_IXUSR)
 
       afterEach ->
         delete process.env.npm_config_node_gyp


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

One of the tests used an async `fs.cp` to copy files from one place to another, but didn't wait for the copy to finish before proceeding with the test. _Usually_, the copy finished fast enough, but sometimes not all of the files would get copied over in time, leading to spurious "module not found" errors from node-gyp. The fix is simple - change the async copy to a sync one (and set permissions as required).

### Alternate Designs

None.

### Benefits

Less flaky tests.

### Possible Drawbacks

None.

### Verification Process

I've committed this change on #840 and #839, and I haven't seen the test fail anymore.

### Applicable Issues

None.