### PR TITLE
Introduce better Node detection

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,7 @@
 .DS_Store
 npm-debug.log
 /spec
-bin/node
+/bin/node*
 .travis.yml
 .pairs
 appveyor.yml

--- a/script/bundled-node-version.js
+++ b/script/bundled-node-version.js
@@ -1,9 +1,23 @@
+var child_process = require('child_process')
+
 module.exports = function(filename, callback) {
-  require('child_process').exec(filename + ' -v', function(error, stdout) {
+  child_process.exec(filename + ' -v', function(error, stdout) {
+    if (error != null) {
+      callback(error);
+      return;
+    }
+
     var version = null;
     if (stdout != null) {
       version = stdout.toString().trim();
     }
-    callback(error, version);
+
+    child_process.exec(filename + " -p 'process.arch'", function(error, stdout) {
+      var arch = null;
+      if (stdout != null) {
+        arch = stdout.toString().trim();
+      }
+      callback(error, version, arch);
+    })
   });
 }

--- a/script/download-node.js
+++ b/script/download-node.js
@@ -81,10 +81,10 @@ var downloadNode = function(version, done) {
   }
 
   if (fs.existsSync(filename)) {
-    getInstallNodeVersion(filename, function(error, installedVersion) {
+    getInstallNodeVersion(filename, function(error, installedVersion, installedArch) {
       if (error != null) {
         done(error);
-      } else if (installedVersion !== version) {
+      } else if (installedVersion !== version || installedArch !== process.arch) {
         downloadFile();
       } else {
         done();

--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -13,6 +13,7 @@ if (process.platform === 'win32') {
 
 // Read + execute permission
 fs.chmodSync(script, fs.constants.S_IRUSR | fs.constants.S_IXUSR)
+fs.chmodSync(path.join(__dirname, '..', 'bin', 'python-interceptor.sh'), fs.constants.S_IRUSR | fs.constants.S_IXUSR)
 
 var child = cp.spawn(script, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true })
 child.stderr.pipe(process.stderr)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

#### The Problem
x86 builds on Azure Devops were using an x64 version of Node to rebuild dependencies. An x86 version of Node was then used to require those dependencies, leading to a fatal exception.

#### The Cause
Lack of Windows developer support. In addition to [no tests on Windows](#839), the development workflow was set up such that it assumed a Unix environment. apm downloads a compatible version of Node for local use, which is ignored when publishing. However, the `npmignore` file only considered the possibility of a `bin/node` file, not the possibility of a `bin/node.exe` file. Thus, when publishing on Windows, the downloaded Node executable was included in the final distribution and picked up by apm's is-Node-already-installed script.

#### The Solution
1. Ignore both `node` and `node.exe` when publishing
2. Download Node if either the version _or_ the arch doesn't match what we expect

### Alternate Designs

None.

### Benefits

* (Hopefully) an end to the debugging saga that atom/atom#19189 has turned into.
* Better support for publishing on Windows.
* Proper matching of OS architecture to Node architecture

### Possible Drawbacks

None. You can still manually replace the downloaded Node version with one of a different architecture post-installation, if you'd like.

### Verification Process

1. Downloaded an x86 version of Node and placed it in `/bin/`
2. Ran `node .\script\postinstall.js`
3. Verified that apm rebuilt its dependencies using an x64 version of Node and that the version in `/bin/` had been replaced by the x64 version

### Applicable Issues

atom/atom#19189