### PR TITLE
Remove unnecessary node-gyp header install logic

### DIFF
--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -485,7 +485,7 @@ describe 'apm install', ->
           modPath = path.join(process.env.ATOM_HOME, 'packages', 'test-git-repo', 'node_modules', dep)
           expect(fs.existsSync(modPath)).toBeTruthy()
 
-    fdescribe 'when installing a Git URL and --json is specified', ->
+    describe 'when installing a Git URL and --json is specified', ->
       [cloneUrl, pkgJsonPath] = []
 
       beforeEach ->
@@ -513,7 +513,7 @@ describe 'apm install', ->
           source: cloneUrl
           sha: sha
 
-    fdescribe 'when installing a registred package and --json is specified', ->
+    describe 'when installing a registred package and --json is specified', ->
       beforeEach ->
         callback = jasmine.createSpy('callback')
         apm.run(['install', "test-module", "test-module2", "--json"], callback)

--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -8,12 +8,12 @@ wrench = require 'wrench'
 apm = require '../lib/apm-cli'
 Install = require '../lib/install'
 
-fdescribe 'apm install', ->
+describe 'apm install', ->
   [atomHome, resourcePath] = []
 
   beforeEach ->
     spyOnToken()
-    silenceOutput(true)
+    silenceOutput()
 
     atomHome = temp.mkdirSync('apm-home-dir-')
     process.env.ATOM_HOME = atomHome
@@ -485,7 +485,7 @@ fdescribe 'apm install', ->
           modPath = path.join(process.env.ATOM_HOME, 'packages', 'test-git-repo', 'node_modules', dep)
           expect(fs.existsSync(modPath)).toBeTruthy()
 
-    describe 'when installing a Git URL and --json is specified', ->
+    fdescribe 'when installing a Git URL and --json is specified', ->
       [cloneUrl, pkgJsonPath] = []
 
       beforeEach ->
@@ -513,7 +513,7 @@ fdescribe 'apm install', ->
           source: cloneUrl
           sha: sha
 
-    describe 'when installing a registred package and --json is specified', ->
+    fdescribe 'when installing a registred package and --json is specified', ->
       beforeEach ->
         callback = jasmine.createSpy('callback')
         apm.run(['install', "test-module", "test-module2", "--json"], callback)

--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -8,12 +8,12 @@ wrench = require 'wrench'
 apm = require '../lib/apm-cli'
 Install = require '../lib/install'
 
-describe 'apm install', ->
+fdescribe 'apm install', ->
   [atomHome, resourcePath] = []
 
   beforeEach ->
     spyOnToken()
-    silenceOutput()
+    silenceOutput(true)
 
     atomHome = temp.mkdirSync('apm-home-dir-')
     process.env.ATOM_HOME = atomHome

--- a/src/ci.coffee
+++ b/src/ci.coffee
@@ -54,6 +54,7 @@ class Ci extends Command
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
+    env.USERPROFILE = env.HOME if config.isWin32()
     @addBuildEnvVars(env)
 
     # node-gyp doesn't currently have an option for this so just set the

--- a/src/ci.coffee
+++ b/src/ci.coffee
@@ -56,16 +56,6 @@ class Ci extends Command
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
     @addBuildEnvVars(env)
 
-    # node-gyp doesn't currently have an option for this so just set the
-    # environment variable to bypass strict SSL
-    # https://github.com/TooTallNate/node-gyp/issues/448
-    useStrictSsl = @npm.config.get('strict-ssl') ? true
-    env.NODE_TLS_REJECT_UNAUTHORIZED = 0 unless useStrictSsl
-
-    # Pass through configured proxy to node-gyp
-    proxy = @npm.config.get('https-proxy') or @npm.config.get('proxy') or env.HTTPS_PROXY or env.HTTP_PROXY
-    installArgs.push("--proxy=#{proxy}") if proxy
-
     installOptions = {env, streaming: options.argv.verbose}
 
     @fork @atomNpmPath, installArgs, installOptions, (args...) =>

--- a/src/ci.coffee
+++ b/src/ci.coffee
@@ -16,7 +16,6 @@ class Ci extends Command
     @atomDirectory = config.getAtomDirectory()
     @atomNodeDirectory = path.join(@atomDirectory, '.node-gyp')
     @atomNpmPath = require.resolve('npm/bin/npm-cli')
-    @atomNodeGypPath = process.env.ATOM_NODE_GYP_PATH or require.resolve('npm/node_modules/node-gyp/bin/node-gyp')
 
   parseOptions: (argv) ->
     options = yargs(argv).wrap(100)
@@ -33,41 +32,6 @@ class Ci extends Command
 
     options.alias('h', 'help').describe('help', 'Print this usage message')
     options.boolean('verbose').default('verbose', false).describe('verbose', 'Show verbose debug information')
-
-  installDependencies: (options, callback) =>
-    async.waterfall [
-      (cb) => @installNode(options, cb)
-      (cb) => @installModules(options, cb)
-    ], callback
-
-  installNode: (options, callback) =>
-    installNodeArgs = ['install']
-    installNodeArgs.push(@getNpmBuildFlags()...)
-    installNodeArgs.push("--ensure")
-    installNodeArgs.push("--verbose") if options.argv.verbose
-
-    env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
-    env.USERPROFILE = env.HOME if config.isWin32()
-
-    fs.makeTreeSync(@atomDirectory)
-
-    # node-gyp doesn't currently have an option for this so just set the
-    # environment variable to bypass strict SSL
-    # https://github.com/TooTallNate/node-gyp/issues/448
-    useStrictSsl = @npm.config.get('strict-ssl') ? true
-    env.NODE_TLS_REJECT_UNAUTHORIZED = 0 unless useStrictSsl
-
-    # Pass through configured proxy to node-gyp
-    proxy = @npm.config.get('https-proxy') or @npm.config.get('proxy') or env.HTTPS_PROXY or env.HTTP_PROXY
-    installNodeArgs.push("--proxy=#{proxy}") if proxy
-
-    opts = {env, cwd: @atomDirectory, streaming: options.argv.verbose}
-
-    @fork @atomNodeGypPath, installNodeArgs, opts, (code, stderr='', stdout='') ->
-      if code is 0
-        callback()
-      else
-        callback("#{stdout}\n#{stderr}")
 
   installModules: (options, callback) ->
     process.stdout.write 'Installing locked modules'
@@ -87,10 +51,21 @@ class Ci extends Command
     if vsArgs = @getVisualStudioFlags()
       installArgs.push(vsArgs)
 
+    fs.makeTreeSync(@atomDirectory)
+
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
-    @updateWindowsEnv(env) if config.isWin32()
-    @addNodeBinToEnv(env)
-    @addProxyToEnv(env)
+    @addBuildEnvVars(env)
+
+    # node-gyp doesn't currently have an option for this so just set the
+    # environment variable to bypass strict SSL
+    # https://github.com/TooTallNate/node-gyp/issues/448
+    useStrictSsl = @npm.config.get('strict-ssl') ? true
+    env.NODE_TLS_REJECT_UNAUTHORIZED = 0 unless useStrictSsl
+
+    # Pass through configured proxy to node-gyp
+    proxy = @npm.config.get('https-proxy') or @npm.config.get('proxy') or env.HTTPS_PROXY or env.HTTP_PROXY
+    installArgs.push("--proxy=#{proxy}") if proxy
+
     installOptions = {env, streaming: options.argv.verbose}
 
     @fork @atomNpmPath, installArgs, installOptions, (args...) =>
@@ -103,7 +78,7 @@ class Ci extends Command
     commands = []
     commands.push (callback) => config.loadNpm (error, @npm) => callback(error)
     commands.push (cb) => @loadInstalledAtomMetadata(cb)
-    commands.push (cb) => @installDependencies(opts, cb)
+    commands.push (cb) => @installModules(opts, cb)
 
     iteratee = (item, next) -> item(next)
     async.mapSeries commands, iteratee, (err) ->

--- a/src/ci.coffee
+++ b/src/ci.coffee
@@ -54,7 +54,6 @@ class Ci extends Command
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
-    env.USERPROFILE = env.HOME if config.isWin32()
     @addBuildEnvVars(env)
 
     # node-gyp doesn't currently have an option for this so just set the

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -117,13 +117,6 @@ class Command
   updateWindowsEnv: (env) ->
     env.USERPROFILE = env.HOME
 
-    # Make sure node-gyp is always on the PATH
-    localModuleBins = path.resolve(__dirname, '..', 'node_modules', '.bin')
-    if env.Path
-      env.Path += "#{path.delimiter}#{localModuleBins}"
-    else
-      env.Path = localModuleBins
-
     git.addGitToEnv(env)
 
   addNodeBinToEnv: (env) ->

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -144,3 +144,13 @@ class Command
     if httpsProxy
       env.HTTPS_PROXY ?= httpsProxy
       env.https_proxy ?= httpsProxy
+
+      # node-gyp only checks HTTP_PROXY (as of May 2019)
+      env.HTTP_PROXY ?= httpsProxy
+      env.http_proxy ?= httpsProxy
+
+    # node-gyp doesn't currently have an option for this so just set the
+    # environment variable to bypass strict SSL
+    # https://github.com/nodejs/node-gyp/issues/448
+    useStrictSsl = @npm.config.get('strict-ssl') ? true
+    env.NODE_TLS_REJECT_UNAUTHORIZED = 0 unless useStrictSsl

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -138,7 +138,7 @@ class Command
       env.HTTPS_PROXY ?= httpsProxy
       env.https_proxy ?= httpsProxy
 
-      # node-gyp only checks HTTP_PROXY (as of May 2019)
+      # node-gyp only checks HTTP_PROXY (as of node-gyp@4.0.0)
       env.HTTP_PROXY ?= httpsProxy
       env.http_proxy ?= httpsProxy
 

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -112,7 +112,7 @@ class Command
       "--msvs_version=#{vsVersion}"
 
   getNpmBuildFlags: ->
-    ["--runtime=electron", "--target=#{@electronVersion}", "--dist-url=#{config.getElectronUrl()}", "--arch=#{config.getElectronArch()}"]
+    ["--target=#{@electronVersion}", "--dist-url=#{config.getElectronUrl()}", "--arch=#{config.getElectronArch()}"]
 
   updateWindowsEnv: (env) ->
     env.USERPROFILE = env.HOME

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -53,16 +53,6 @@ class Dedupe extends Command
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
     @addBuildEnvVars(env)
 
-    # node-gyp doesn't currently have an option for this so just set the
-    # environment variable to bypass strict SSL
-    # https://github.com/TooTallNate/node-gyp/issues/448
-    useStrictSsl = @npm.config.get('strict-ssl') ? true
-    env.NODE_TLS_REJECT_UNAUTHORIZED = 0 unless useStrictSsl
-
-    # Pass through configured proxy to node-gyp
-    proxy = @npm.config.get('https-proxy') or @npm.config.get('proxy') or env.HTTPS_PROXY or env.HTTP_PROXY
-    dedupeArgs.push("--proxy=#{proxy}") if proxy
-
     dedupeOptions = {env}
     dedupeOptions.cwd = options.cwd if options.cwd
 

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -51,7 +51,6 @@ class Dedupe extends Command
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
-    env.USERPROFILE = env.HOME if config.isWin32()
     @addBuildEnvVars(env)
 
     # node-gyp doesn't currently have an option for this so just set the

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -334,7 +334,7 @@ class Install extends Command
   # callback - The callback function to invoke when done with an error as the
   #            first argument.
   installPackageDependencies: (options, callback) ->
-    options = _.extend({}, options, installGlobally: false, installNode: false)
+    options = _.extend({}, options, installGlobally: false)
     commands = []
     for name, version of @getPackageDependencies()
       do (name, version) =>

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -76,7 +76,6 @@ class Install extends Command
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
-    env.USERPROFILE = env.HOME if config.isWin32()
     @addBuildEnvVars(env)
 
     # node-gyp doesn't currently have an option for this so just set the
@@ -182,7 +181,6 @@ class Install extends Command
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
-    env.USERPROFILE = env.HOME if config.isWin32()
     @addBuildEnvVars(env)
 
     # node-gyp doesn't currently have an option for this so just set the

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -183,16 +183,6 @@ class Install extends Command
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
     @addBuildEnvVars(env)
 
-    # node-gyp doesn't currently have an option for this so just set the
-    # environment variable to bypass strict SSL
-    # https://github.com/TooTallNate/node-gyp/issues/448
-    useStrictSsl = @npm.config.get('strict-ssl') ? true
-    env.NODE_TLS_REJECT_UNAUTHORIZED = 0 unless useStrictSsl
-
-    # Pass through configured proxy to node-gyp
-    proxy = @npm.config.get('https-proxy') or @npm.config.get('proxy') or env.HTTPS_PROXY or env.HTTP_PROXY
-    installArgs.push("--proxy=#{proxy}") if proxy
-
     installOptions = {env}
     installOptions.cwd = options.cwd if options.cwd
     installOptions.streaming = true if @verbose

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -78,16 +78,6 @@ class Install extends Command
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
     @addBuildEnvVars(env)
 
-    # node-gyp doesn't currently have an option for this so just set the
-    # environment variable to bypass strict SSL
-    # https://github.com/TooTallNate/node-gyp/issues/448
-    useStrictSsl = @npm.config.get('strict-ssl') ? true
-    env.NODE_TLS_REJECT_UNAUTHORIZED = 0 unless useStrictSsl
-
-    # Pass through configured proxy to node-gyp
-    proxy = @npm.config.get('https-proxy') or @npm.config.get('proxy') or env.HTTPS_PROXY or env.HTTP_PROXY
-    installArgs.push("--proxy=#{proxy}") if proxy
-
     installOptions = {env}
     installOptions.streaming = true if @verbose
 
@@ -395,16 +385,6 @@ class Install extends Command
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
     @addBuildEnvVars(env)
-
-    # node-gyp doesn't currently have an option for this so just set the
-    # environment variable to bypass strict SSL
-    # https://github.com/TooTallNate/node-gyp/issues/448
-    useStrictSsl = @npm.config.get('strict-ssl') ? true
-    env.NODE_TLS_REJECT_UNAUTHORIZED = 0 unless useStrictSsl
-
-    # Pass through configured proxy to node-gyp
-    proxy = @npm.config.get('https-proxy') or @npm.config.get('proxy') or env.HTTPS_PROXY or env.HTTP_PROXY
-    buildArgs.push("--proxy=#{proxy}") if proxy
 
     buildOptions = {env}
     buildOptions.streaming = true if @verbose

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -5,6 +5,7 @@ yargs = require 'yargs'
 
 config = require './apm'
 Command = require './command'
+fs = require './fs'
 Install = require './install'
 
 module.exports =
@@ -13,7 +14,8 @@ class Rebuild extends Command
 
   constructor: ->
     super()
-    @atomNodeDirectory = path.join(config.getAtomDirectory(), '.node-gyp')
+    @atomDirectory = config.getAtomDirectory()
+    @atomNodeDirectory = path.join(@atomDirectory, '.node-gyp')
     @atomNpmPath = require.resolve('npm/bin/npm-cli')
 
   parseOptions: (argv) ->

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -44,18 +44,7 @@ class Rebuild extends Command
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
-    env.USERPROFILE = env.HOME if config.isWin32()
     @addBuildEnvVars(env)
-
-    # node-gyp doesn't currently have an option for this so just set the
-    # environment variable to bypass strict SSL
-    # https://github.com/TooTallNate/node-gyp/issues/448
-    useStrictSsl = @npm.config.get('strict-ssl') ? true
-    env.NODE_TLS_REJECT_UNAUTHORIZED = 0 unless useStrictSsl
-
-    # Pass through configured proxy to node-gyp
-    proxy = @npm.config.get('https-proxy') or @npm.config.get('proxy') or env.HTTPS_PROXY or env.HTTP_PROXY
-    rebuildArgs.push("--proxy=#{proxy}") if proxy
 
     @fork(@atomNpmPath, rebuildArgs, {env}, callback)
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Currently, any time we have a command that does something related to `npm install`, we ensure that the Electron header versions are correctly installed by spawning a process to run `node-gyp install` with the correct Electron version, header URL, etc. It turns out that `node-gyp` will actually [do this for us](https://github.com/nodejs/node-gyp/blob/721eb691cf15556cc2700eda0558d5bad5f84232/lib/configure.js#L71) automatically as long as you supply the correct arguments to the relevant `npm` commands. Yay!

### Alternate Designs

None.

### Benefits

There's pretty much no node-gyp code in the codebase now -- it's all handled through npm.

### Possible Drawbacks

I don't really see any.

### Verification Process

All the specs pass, which depend on node-gyp finding and downloading the correct header files.

### Applicable Issues

None, but can be seen as a followup to #832

### Todo

* [x] Yank out proxy logic into a helper function for further de-duplication