### PR TITLE
chmod all the scripts in bin

### DIFF
--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -13,6 +13,8 @@ if (process.platform === 'win32') {
 
 // Read + execute permission
 fs.chmodSync(script, fs.constants.S_IRUSR | fs.constants.S_IXUSR)
+fs.chmodSync(path.join(__dirname, '..', 'bin', 'apm'), fs.constants.S_IRUSR | fs.constants.S_IXUSR)
+fs.chmodSync(path.join(__dirname, '..', 'bin', 'npm'), fs.constants.S_IRUSR | fs.constants.S_IXUSR)
 fs.chmodSync(path.join(__dirname, '..', 'bin', 'python-interceptor.sh'), fs.constants.S_IRUSR | fs.constants.S_IXUSR)
 
 var child = cp.spawn(script, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: true })


### PR DESCRIPTION
Just chmod all of them to be safe. We've been running into permission errors with ./bin/npm.