### PR TITLE
Use disturl, not dist-url

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -112,7 +112,7 @@ class Command
       "--msvs_version=#{vsVersion}"
 
   getNpmBuildFlags: ->
-    ["--target=#{@electronVersion}", "--dist-url=#{config.getElectronUrl()}", "--arch=#{config.getElectronArch()}"]
+    ["--target=#{@electronVersion}", "--disturl=#{config.getElectronUrl()}", "--arch=#{config.getElectronArch()}"]
 
   updateWindowsEnv: (env) ->
     env.USERPROFILE = env.HOME


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

_Something_ in npm doesn't seem to like the hyphen in `dist-url`, and the argument doesn't get passed down correctly to node-gyp. This is evidenced by the fact that the corresponding environment variable for this flag is `npm_config_disturl`, **not** `npm_config_dist_url`, and that node-gyp [also accepts `--disturl`](https://github.com/nodejs/node-gyp/blob/81f3a923386acfedf22d5b8c34372ec41e3b3096/lib/process-release.js#L18).

Therefore, change the flag to `--disturl` so that things work correctly and we don't try to download iojs.

### Alternate Designs

* Specify all the build flags as environment variables
* Specify all the build flags as options in `.apmrc`

Both of these alternatives have a lower precedence than command-line arguments.

### Benefits

Regression fix from #845.

### Possible Drawbacks

None.

### Verification Process

Removed my cached Electron headers and tried to build a native module with this change. They got re-downloaded :+1:.

### Applicable Issues

N/A