### PR TITLE
Resolve `.` as folder name when uninstalling

### DIFF
--- a/src/uninstall.coffee
+++ b/src/uninstall.coffee
@@ -62,6 +62,8 @@ class Uninstall extends Command
     uninstallError = null
 
     for packageName in packageNames
+      if packageName is '.'
+        packageName = path.basename(process.cwd())
       process.stdout.write "Uninstalling #{packageName} "
       try
         unless options.argv.dev


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Resolves `.` to the name of the current directory when running `apm uninstall .`. It then continues as if the resolved value was the one passed in the first place.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
Exactly what to resolve `.` to is tricky. IMO, resolving to the exact current directory is reasonable, but then it doesn't respect the `--dev` flags and such. It also turns the command into a pseudo `rm -rf` instruction, which could be dangerous (it already acts like this on the `packages` directory, and is very annoying). As this PR is currently, any mistakes are isolated to the `packages` and `dev/packages` directories.

That alternative may work better if it first checks that the current folder is the root of an Atom package. But I still think it's best to let a user manage their directories themselves if it's not inside `.atom`.
 

### Benefits

<!-- What benefits will be realized by the code change? -->
Will no longer delete the entire `~/.atom/packages` folder. This happened because `path.resolve` was resolving the packages path with the package `.`, which is still the packages path, and that folder was deleted.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Not necessarily removing the exact folder this was called from (as describe in Alternatives) may be surprising. I made my case there, but could try adding proper relative path support (with package check guard & making sure the resolved path is in the packages directory).

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->
Ran it on macOS 10.14.4, and added a test.

### Applicable Issues

<!-- Enter any applicable Issues here -->
closes #460