### PR TITLE
Improved publish version message

### DIFF
--- a/src/publish.coffee
+++ b/src/publish.coffee
@@ -36,6 +36,9 @@ class Publish extends Command
       it is published to the apm registry. The HEAD branch and the new tag are
       pushed up to the remote repository automatically using this option.
 
+      If a tag is provided via the --tag flag, it must have the form `vx.y.z`.
+      For example, `apm publish -t v1.12.0`.
+
       If a new name is provided via the --rename flag, the package.json file is
       updated with the new name and the package's name is updated on Atom.io.
 
@@ -44,7 +47,7 @@ class Publish extends Command
       have published it.
     """
     options.alias('h', 'help').describe('help', 'Print this usage message')
-    options.alias('t', 'tag').string('tag').describe('tag', 'Specify a tag to publish')
+    options.alias('t', 'tag').string('tag').describe('tag', 'Specify a tag to publish. Must be of the form vx.y.z')
     options.alias('r', 'rename').string('rename').describe('rename', 'Specify a new name for the package')
 
   # Create a new version and tag use the `npm version` command.

--- a/src/publish.coffee
+++ b/src/publish.coffee
@@ -54,7 +54,7 @@ class Publish extends Command
   #            argument and a the generated tag string as the second argument.
   versionPackage: (version, callback) ->
     process.stdout.write 'Preparing and tagging a new version '
-    versionArgs = ['version', version, '-m', 'Prepare %s release']
+    versionArgs = ['version', version, '-m', 'Prepare v%s release']
     @fork @atomNpmPath, versionArgs, (code, stderr='', stdout='') =>
       if code is 0
         @logSuccess()


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Publishing doc tweaks:
- Adds a `v` to the publish message; from `Prepare 1.12.0 release` to `Prepare v1.12.0 release`
- Expands the description of the `--tag` flag to specify `v` is required.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
Could remove the `Must be of the form vx.y.z` message from the inline flag description, as it's also stated in the block of text, but I feel it's easier not to miss if it's also there.

### Benefits

<!-- What benefits will be realized by the code change? -->
Make required steps clearer.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
none

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Tested `npm version minor -m "Prepare v%s release"` on a dummy package; the git commit message was `Prepare v0.38.0 release` as expected.

The doc changes were verified by running `apm help publish`.

### Applicable Issues

<!-- Enter any applicable Issues here -->
closes #724
also addresses https://github.com/atom/atom.io/issues/118#issuecomment-301992922