### PR TITLE
Only delete folders containing a package.json on uninstall

### DIFF
--- a/spec/uninstall-spec.coffee
+++ b/spec/uninstall-spec.coffee
@@ -58,6 +58,20 @@ describe 'apm uninstall', ->
       runs ->
         expect(fs.existsSync(packagePath)).toBeFalsy()
 
+  describe 'when the package folder exists but does not contain a package.json', ->
+    it 'does not delete the folder', ->
+      {packagePath} = createPackage('test-package')
+      fs.unlinkSync(path.join(packagePath, 'package.json'))
+
+      callback = jasmine.createSpy('callback')
+      apm.run(['uninstall', 'test-package'], callback)
+
+      waitsFor 'waiting for command to complete', ->
+        callback.callCount > 0
+
+      runs ->
+        expect(fs.existsSync(packagePath)).toBeTruthy()
+
     describe 'when . is specified as the package name', ->
       it 'resolves to the basename of the cwd', ->
         {packagePath} = createPackage('test-package')

--- a/src/uninstall.coffee
+++ b/src/uninstall.coffee
@@ -68,13 +68,14 @@ class Uninstall extends Command
       try
         unless options.argv.dev
           packageDirectory = path.join(packagesDirectory, packageName)
-          if fs.existsSync(packageDirectory)
+          packageManifestPath = path.join(packageDirectory, 'package.json')
+          if fs.existsSync(packageManifestPath)
             packageVersion = @getPackageVersion(packageDirectory)
             fs.removeSync(packageDirectory)
             if packageVersion
               uninstallsToRegister.push({packageName, packageVersion})
           else if not options.argv.hard
-            throw new Error("Does not exist")
+            throw new Error("No package.json found at #{packageManifestPath}")
 
         if options.argv.hard or options.argv.dev
           packageDirectory = path.join(devPackagesDirectory, packageName)


### PR DESCRIPTION
When running `apm uninstall foo`, we construct a path like `~/.atom/packages/foo` to determine which package folder to remove. We added a special case for `apm uninstall .` in #854, but this still leaves us vulnerable to things like `apm uninstall ..`, which would delete the entire `.atom` folder. To protect against this, this PR updates `apm` to only delete the resolved folder if it contains a `package.json` file.

/cc @Aerijo 