### PR TITLE
Add build env values

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -106,6 +106,11 @@ class Command
     @updateWindowsEnv(env) if config.isWin32()
     @addNodeBinToEnv(env)
     @addProxyToEnv(env)
+    env.npm_config_runtime = "electron"
+    env.npm_config_target = @electronVersion
+    env.npm_config_disturl = config.getElectronUrl()
+    env.npm_config_arch = config.getElectronArch()
+    env.npm_config_target_arch = config.getElectronArch() # for node-pre-gyp
 
   getVisualStudioFlags: ->
     if vsVersion = config.getInstalledVisualStudioFlag()


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Adds the build environment as environment variables. This is more robust than flags, as the process environment will normally be passed along, even if the installation script does not handle and pass the flags.

For example, see [node-pty](https://github.com/microsoft/node-pty/blob/master/scripts/install.js). It defines a custom install script, which does not pass any outer flags to node-gyp. It does use the default `process.env` however.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
Could potentially remove the flags now, but I wanted to keep the impact minimal.

### Benefits

<!-- What benefits will be realized by the code change? -->
If the build works, it's probably for the intended Atom version now.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
na.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Successful terminal installation and use in relatively fresh Ubuntu 19.04 VM when installed with `apm-nightly install termination`. Note a related bug may cause Atom to report the installed version as wrong. If this happens, first try deleting the `installed-packages:termination:...` entries in `localstorage` and reloading.

### Applicable Issues

<!-- Enter any applicable Issues here -->
I don't know anything about building on Windows, especially how `msvs_version` is used. While this PR does not harm Windows, it would be good for someone to confirm if more env variables need to be passed to support it.

Edit: It worked on a Windows 10 VM too, where build tools were installed with `npm install -g windows-build-tools`.

Fixes #860