### PR TITLE
Add flag to list to not show packages' versions

### DIFF
--- a/spec/list-spec.coffee
+++ b/spec/list-spec.coffee
@@ -77,6 +77,19 @@ describe 'apm list', ->
       expect(lines[10]).toMatch /git-package@1\.0\.0/
       expect(lines.join("\n")).not.toContain '.bin' # ensure invalid packages aren't listed
 
+  it 'lists the installed packages without versions with --no-versions', ->
+    listPackages ['--no-versions'], ->
+      lines = console.log.argsForCall.map((arr) -> arr.join(' '))
+      expect(lines[0]).toMatch /Built-in Atom Packages.*1/
+      expect(lines[1]).toMatch /test-module/
+      expect(lines[3]).toMatch /Dev Packages.*1/
+      expect(lines[4]).toMatch /dev-package/
+      expect(lines[6]).toMatch /Community Packages.*1/
+      expect(lines[7]).toMatch /user-package/
+      expect(lines[9]).toMatch /Git Packages.*1/
+      expect(lines[10]).toMatch /git-package/
+      expect(lines.join("\n")).not.toContain '.bin' # ensure invalid packages aren't listed
+
   describe 'enabling and disabling packages', ->
     beforeEach ->
       packagesPath = path.join(atomHome, 'packages')
@@ -111,6 +124,22 @@ describe 'apm list', ->
       expect(json.dev).toEqual [name: 'dev-package', version: '1.0.0']
       expect(json.git).toEqual [name: 'git-package', version: '1.0.0', apmInstallSource: apmInstallSource]
       expect(json.user).toEqual [name: 'user-package', version: '1.0.0']
+
+  it 'lists packages in bare format when --bare is passed', ->
+    listPackages ['--bare'], ->
+      lines = console.log.argsForCall.map((arr) -> arr.join(' '))
+      expect(lines[0]).toMatch /test-module@1\.0\.0/
+      expect(lines[1]).toMatch /dev-package@1\.0\.0/
+      expect(lines[2]).toMatch /user-package@1\.0\.0/
+      expect(lines[3]).toMatch /git-package@1\.0\.0/
+
+  it 'list packages in bare format without versions when --bare --no-versions is passed', ->
+    listPackages ['--bare', '--no-versions'], ->
+      lines = console.log.argsForCall.map((arr) -> arr.join(' '))
+      expect(lines[0]).toMatch /test-module/
+      expect(lines[1]).toMatch /dev-package/
+      expect(lines[2]).toMatch /user-package/
+      expect(lines[3]).toMatch /git-package/
 
   describe 'when a section is empty', ->
     it 'does not list anything for Dev and Git sections', ->

--- a/src/list.coffee
+++ b/src/list.coffee
@@ -47,6 +47,7 @@ class List extends Command
     options.alias('l', 'links').boolean('links').default('links', true).describe('links', 'Include linked packages')
     options.alias('t', 'themes').boolean('themes').describe('themes', 'Only list themes')
     options.alias('p', 'packages').boolean('packages').describe('packages', 'Only list packages')
+    options.alias('v', 'versions').boolean('versions').default('versions', true).describe('versions', 'Include version of each package')
 
   isPackageDisabled: (name) ->
     @disabledPackages.indexOf(name) isnt -1
@@ -55,12 +56,12 @@ class List extends Command
     if options.argv.bare
       for pack in packages
         packageLine = pack.name
-        packageLine += "@#{pack.version}" if pack.version?
+        packageLine += "@#{pack.version}" if pack.version? and options.argv.versions
         console.log packageLine
     else
       tree packages, (pack) =>
         packageLine = pack.name
-        packageLine += "@#{pack.version}" if pack.version?
+        packageLine += "@#{pack.version}" if pack.version? and options.argv.versions
         if pack.apmInstallSource?.type is 'git'
           repo = getRepository(pack)
           shaLine = "##{pack.apmInstallSource.sha.substr(0, 8)}"
@@ -68,7 +69,7 @@ class List extends Command
           packageLine += " (#{shaLine})".grey
         packageLine += ' (disabled)' if @isPackageDisabled(pack.name) and not options.argv.disabled
         packageLine
-    console.log()
+      console.log()
 
   checkExclusiveOptions: (options, positive_option, negative_option, value) ->
     if options.argv[positive_option]


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

`apm list` is used to list the currently used packages. There's multiple flags to it, but this PR only touches on the default behaviour of `apm list`, and `apm list --bare`.

`apm list` will print out a nicely formatted tree structure, listing, for each type of package, the package name and its version, with the format `package-name@package-version`. And with a newline of separation between each package type tier.

`apm list --bare`, will work similarly, but it will only print out the package with the previous format, and will not have any tree structure, nor will it include what type of package the list ones are.

This PR adds a new flag, always true by default, `--versions`, that when used as `--no-versions` will not display the version information on both of those commands, leaving the format as simply `package-name`.

And a smaller change is that it will also remove that newline between types of packages **for `--bare`.** Currently `--bare` still prints a newline between different types, but in my opinion it's unhelpful since no information on package type is shown. To illustrate my point, here's the default (minified for brevity) formatting of both commands here:

`apm list`
```
Built-in Atom Packages (93)
├── atom-dark-syntax@0.29.1
├── dalek@0.2.2
└── language-yaml@0.32.0

Community Packages (35) $HOME/.atom/packages
├── ava@0.12.0
├── fonts@3.7.2
└── multi-wrap-guide@1.1.8

```

`apm list --bare`
```
atom-dark-syntax@0.29.1
dalek@0.2.2
language-yaml@0.32.0

ava@0.12.0
fonts@3.7.2
multi-wrap-guide@1.1.8

```

As you see, those newlines are useful on the default formatting to separate package types. However, on the `--bare` flag, they provide no meaningful information, since the package type and the current ordering used is not known, and only complicate scripting and testing.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I believe this is the most straightforward way of doing this, so it didn't occur to me to think of any alternate designs. I cannot think of any either.

### Benefits

<!-- What benefits will be realized by the code change? -->

I can talk about my usecase here: I use the `apm list --bare` command to always keep an up-to-date file on my dotfiles repository of my currently installed packages and themes so I can keep the same packages across different systems. With the current implementation of it I couldn't quite do so since with the default list command the version information would be printed out, meaning by the time I install Atom and its packages on another system, those packages might be out of date.

So to simplify scripting and these kinds of usecases, I added this `--versions` flag, that will be true by default, keeping the same default functionality, but that will allow, when used as `--no-versions` to skip the version information making it easier to simply keep a list of installed package without its currently installed version.

The removed newline for `--bare` also makes it a bit easier for scripting uses. And in this case allows for somewhat easier test cases. With the included newline, the test case would have had to check for arbitrary newlines, and it would have relied on a specific package type ordering when printing the packages. Removing the newline allows the test cases to simply check that each line has a given test package.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

As I mention, this flag is active by default, meaning an user that might be relying on the default or `--bare` commands will not see any change with the versions.

However, a change might be noticed when used with `--bare` since the newline separating package types has been removed.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- **How did you verify that all new functionality works as expected?** I wrote both new test cases, and ran the new flag multiple times for manual testing.
- **How did you verify that all changed functionality works as expected?** I tried the new flag in combination with already existing flags.
- **How did you verify that the change has not introduced any regressions?** I wrote test cases for both the new functionality, and previous functionality that were not covered by tests but that might affected by the new functionality.

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

I downloaded and installed `apm` from source, so I could `run build` and run `test`. I tried the new flag with both `apm list` and `apm list --bare`, making sure the default behaviour stayed the same, and that when using the `--no-versions` flag versions would not be displayed. I also tried it in combination with `--packages`, `--themes`, and `--installed`, and a combination of those three.

I also made sure all of the previous tests still passed, and that the new functionality was covered by new tests that did also pass.
