### PR TITLE
Fix textmate language template spec

### DIFF
--- a/templates/language/spec/language-__package-name__-spec.coffee.template
+++ b/templates/language/spec/language-__package-name__-spec.coffee.template
@@ -9,7 +9,7 @@ describe "__PackageName__ grammar", ->
       atom.packages.activatePackage("language-__package-name__")
 
     runs ->
-      grammar = atom.syntax.grammarForScopeName("source.__package-name__")
+      grammar = atom.grammars.grammarForScopeName("source.__package-name__")
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()


### PR DESCRIPTION
The `atom.syntax` global doesn't exist. This PR renames it to `atom.grammars` to make the specs for a template repo pass.
