### PR TITLE
Better Support for Visual Studio 2017 and 2019

### DIFF
--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -93,7 +93,10 @@ module.exports =
     return '2010' if @visualStudioIsInstalled("10.0")
 
   visualStudioIsInstalled: (version) ->
-    fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio #{version}", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "BuildTools", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "Community", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "Enterprise", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "Professional", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "WDExpress", "Common7", "IDE"))
+    if version < 2017
+      fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio #{version}", "Common7", "IDE"))
+    else
+      fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "BuildTools", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "Community", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "Enterprise", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "Professional", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "WDExpress", "Common7", "IDE"))
 
   loadNpm: (callback) ->
     npmOptions =

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -88,9 +88,6 @@ module.exports =
     return '2019' if @visualStudioIsInstalled("2019")
     return '2017' if @visualStudioIsInstalled("2017")
     return '2015' if @visualStudioIsInstalled("14.0")
-    return '2013' if @visualStudioIsInstalled("12.0")
-    return '2012' if @visualStudioIsInstalled("11.0")
-    return '2010' if @visualStudioIsInstalled("10.0")
 
   visualStudioIsInstalled: (version) ->
     if version < 2017

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -85,13 +85,15 @@ module.exports =
     # Use the explictly-configured version when set
     return process.env.GYP_MSVS_VERSION if process.env.GYP_MSVS_VERSION
 
+    return '2019' if @visualStudioIsInstalled("2019")
+    return '2017' if @visualStudioIsInstalled("2017")
     return '2015' if @visualStudioIsInstalled("14.0")
     return '2013' if @visualStudioIsInstalled("12.0")
     return '2012' if @visualStudioIsInstalled("11.0")
     return '2010' if @visualStudioIsInstalled("10.0")
 
   visualStudioIsInstalled: (version) ->
-    fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio #{version}", "Common7", "IDE"))
+    fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio #{version}", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "BuildTools", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "Community", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "Enterprise", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "Professional", "Common7", "IDE")) or fs.existsSync(path.join(@x86ProgramFilesDirectory(), "Microsoft Visual Studio", "#{version}", "WDExpress", "Common7", "IDE"))
 
   loadNpm: (callback) ->
     npmOptions =

--- a/src/ci.coffee
+++ b/src/ci.coffee
@@ -48,9 +48,6 @@ class Ci extends Command
     ]
     installArgs.push('--verbose') if options.argv.verbose
 
-    if vsArgs = @getVisualStudioFlags()
-      installArgs.push(vsArgs)
-
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -112,10 +112,6 @@ class Command
     env.npm_config_arch = config.getElectronArch()
     env.npm_config_target_arch = config.getElectronArch() # for node-pre-gyp
 
-  getVisualStudioFlags: ->
-    if vsVersion = config.getInstalledVisualStudioFlag()
-      "--msvs_version=#{vsVersion}"
-
   getNpmBuildFlags: ->
     ["--target=#{@electronVersion}", "--disturl=#{config.getElectronUrl()}", "--arch=#{config.getElectronArch()}"]
 

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -43,9 +43,6 @@ class Dedupe extends Command
     dedupeArgs.push('--silent') if options.argv.silent
     dedupeArgs.push('--quiet') if options.argv.quiet
 
-    if vsArgs = @getVisualStudioFlags()
-      dedupeArgs.push(vsArgs)
-
     dedupeArgs.push(packageName) for packageName in options.argv._
 
     fs.makeTreeSync(@atomDirectory)

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -70,9 +70,6 @@ class Install extends Command
     installArgs.push('--quiet') if options.argv.quiet
     installArgs.push('--production') if options.argv.production
 
-    if vsArgs = @getVisualStudioFlags()
-      installArgs.push(vsArgs)
-
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
@@ -164,9 +161,6 @@ class Install extends Command
     installArgs.push('--silent') if options.argv.silent
     installArgs.push('--quiet') if options.argv.quiet
     installArgs.push('--production') if options.argv.production
-
-    if vsArgs = @getVisualStudioFlags()
-      installArgs.push(vsArgs)
 
     fs.makeTreeSync(@atomDirectory)
 
@@ -377,9 +371,6 @@ class Install extends Command
     buildArgs = ['--globalconfig', config.getGlobalConfigPath(), '--userconfig', config.getUserConfigPath(), 'build']
     buildArgs.push(path.resolve(__dirname, '..', 'native-module'))
     buildArgs.push(@getNpmBuildFlags()...)
-
-    if vsArgs = @getVisualStudioFlags()
-      buildArgs.push(vsArgs)
 
     fs.makeTreeSync(@atomDirectory)
 

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -38,9 +38,6 @@ class Rebuild extends Command
     rebuildArgs.push(@getNpmBuildFlags()...)
     rebuildArgs.push(options.argv._...)
 
-    if vsArgs = @getVisualStudioFlags()
-      rebuildArgs.push(vsArgs)
-
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Main change:
- Detect Visual Studio 2017 and 2019

Related changes:
- Stop detecting unsupported versions, which node-gyp refuses to use (Visual Studio 2010 - 2013)
- Don't set the `--msvs_version` node-gyp flag, which sets a specific version of Visual Studio that node-gyp must find, or else it will error out.
  - Our detection for actually-working Visual Studio installs is substantially worse than node-gyp's. We should let them detect and use whatever usable version of Visual Studio they can find.

<details><summary>Explanation (click to expand):</summary>

Builds on `apm`'s existing code to detect installs of Visual Studio, by adding the ability to detect Visual Studio 2017 and 2019.

Those versions of Visual Studio are now [fully](https://github.com/nodejs/node-gyp/blob/master/CHANGELOG.md#v500-2019-06-13) [supported](https://github.com/nodejs/node-gyp/pull/1762) in the version of node-gyp we use (node-gyp@5).

As of node-gyp PR https://github.com/nodejs/node-gyp/pull/1762, node-gyp is much better than us at finding Visual Studio installs and identifying whether on not they can be used. This isn't a simple matter of having Visual Studio or not, but also various components [must be installed](https://github.com/atom-ide-community/atom/pull/44#issuecomment-657164136).

Given that our detection is worse, I have made it so `apm` no-longer sets the [`--msvs_version`](https://github.com/nodejs/node-gyp#command-options) flag. This flag forces node-gyp to use the specified major version of Visual Studio/Build Tools. It can only restrict node-gyp within usable installs. There is no scenario where setting this causes any benefit to us. But if we get it wrong (and our detection is worse, so we very likely would), this can cause node-gyp to refuse to use a valid Visual Studio/Build Tools install and error out.

</details>

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

This, but with some of the changes reverted/taken out.

<details>

All commits in this PR are designed to be logical choices that are well-backed-up by the explanation and reasoning given.

That said, the commits are in order of how radical the change is, or how controversial I thought the change might be. If any of the commits/changes are objectionable, please let me know, and the rest of the PR still makes sense without that change. This is a few related changes bundled together, but any of the three bullet points is a positive step in the right direction, and works independent of the other two bullet points.

</details>

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

- Lets apm and node-gyp use Visual Studio 2017 and 2019, even if 2015 or older is also installed
- Stops causing errors for our users, such as by rejecting Visual Studio 2017 and 2019 if a buggy 2015 or earlier install is the first one found
- Gets out of the way of a critical dependency detection task that node-gyp is doing better than us at
- More successful package builds, more happy customers?
- Keeps up with the latest Visual Studio major versions we support (via node-gyp).

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

None that I am aware of. Before this PR, we have been artificially limiting how good a job node-gyp could do to find Visual Studio, in certain cases. Now, with this PR, we stop doing that.

Reaching for a hypothetical problem: I suppose if Visual Studio 2017 or 2019 are buggy, this exposes our users to that. (In my experience, VS 2017 and 2019 are _**not**_ buggy.)

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<details><summary>Lengthy "Verification Process" section contents (click to expand):</summary>

This un-blocks `apm` from using a correctly-detected, working install of Visual Studio 2019 in (forked) Atom's CI.

- Before: https://dev.azure.com/atomcommunity/atomcommunity/_build/results?buildId=176&view=logs&j=97a617bf-bcbd-5dfa-bba2-cfba2747b693&t=1e1369e9-1c56-59b0-830c-f1606a680c8a&l=32
- After: https://dev.azure.com/atomcommunity/atomcommunity/_build/results?buildId=177&view=logs&j=97a617bf-bcbd-5dfa-bba2-cfba2747b693&t=1e1369e9-1c56-59b0-830c-f1606a680c8a

Breakdown of the "Before" case: The issue in this case was that `apm` detected an install of 2015 that turned out to be unusable. The error is: "`could not find MSBuild in registry for this version`". At the bottom of the error message, a message points out that 2019 would have been a valid version, had we allowed node-gyp to use it:

```console
gyp ERR! find VS valid versions for msvs_version:
gyp ERR! find VS - "2019"
gyp ERR! find VS - "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise"
``` 

---

Furthermore, `apm --version` can now find Visual Studio 2017 and 2019.

Before and after on the same machine, with Visual Studio 2019 Community installed:

##### Before: 
```console
C:\Users\[User]\>apm-dev --version
apm  2.5.0
npm  6.14.5
node 10.20.1 x64
atom 1.50.0-dev-110b05baf
python 2.7.18
git 2.27.0.windows.1
visual studio
```

##### After:
```console

C:\Users\[User]>apm-dev --version
apm  2.5.0
npm  6.14.5
node 10.20.1 x64
atom 1.51.0-dev-912dad331
python 2.7.18
git 2.27.0.windows.1
visual studio 2019
```
Note that Visual Studio 2019 is detected: `visual studio 2019` (on the bottom line of output from `apm --version`).

Here's the before and after on another machine, this time with Visual Studio 2017:

##### Before
```console
C:\Users\[User]>apm-dev --version
apm  2.5.0
npm  6.14.5
node 10.20.1 x64
atom 1.50.0-dev-9c16e5c67
python 2.7.18
git 2.27.0.windows.1
visual studio
```
##### After
```console
C:\Users\[User]>apm-dev --version
apm  2.5.0
npm  6.14.5
node 10.20.1 x64
atom 1.51.0-dev-912dad331
python 2.7.18
git 2.27.0.windows.1
visual studio 2017
```

Note that Visual Studio 2017 is detected: `visual studio 2017` (on the bottom line of output from `apm --version`).

</details>

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

<!-- Enter any applicable Issues here -->

Fixes #893