### PR TITLE
Fix getResourcePath so more apm commands work on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -261,6 +261,20 @@
         "mkdirp": "^0.5.0",
         "mksnapshot": "^0.3.0",
         "tmp": "0.0.28"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "asar-require": {
@@ -633,19 +647,6 @@
         "y18n": "^4.0.0"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -921,20 +922,6 @@
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
           "integrity": "sha1-vxxHrWREOg2V0S3ysUfMCk2q1uk=",
           "dev": true
-        },
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
         },
         "resolve": {
           "version": "0.6.3",
@@ -2516,13 +2503,14 @@
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
     "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "requires": {
+        "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "2 || 3",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -3066,21 +3054,6 @@
         "semver": "2.x || 3.x || 4 || 5",
         "validate-npm-package-license": "^3.0.1",
         "validate-npm-package-name": "^3.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "interpret": {
@@ -4657,19 +4630,6 @@
         "which": "^1.3.1"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -4969,19 +4929,6 @@
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "requires": {
             "pump": "^3.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -5782,19 +5729,6 @@
             "pump": "^3.0.0"
           }
         },
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6243,21 +6177,6 @@
         "json-parse-better-errors": "^1.0.1",
         "normalize-package-data": "^2.0.0",
         "npm-normalize-package-bin": "^1.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "read-package-tree": {
@@ -6469,21 +6388,6 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
         "glob": "^7.1.3"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "run-queue": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "first-mate": "^7.4.1",
     "fs-plus": "2.x",
     "git-utils": "^5.6.2",
+    "glob": "^7.1.6",
     "hosted-git-info": "^2.1.4",
     "keytar": "^4.13.0",
     "mv": "2.0.0",

--- a/spec/apm-cli-spec.coffee
+++ b/spec/apm-cli-spec.coffee
@@ -44,6 +44,24 @@ describe 'apm command line interface', ->
         expect(lines[2]).toBe "node #{process.versions.node} #{process.arch}"
         expect(lines[3]).toBe "atom #{testAtomVersion}"
 
+  describe 'when the version flag is specified but env.ATOM_RESOURCE_PATH is not set', ->
+    it 'finds the installed Atom and prints the version', ->
+      callback = jasmine.createSpy('callback')
+      apm.run(['-v', '--no-color'], callback)
+
+      process.env.ATOM_RESOURCE_PATH = ''
+
+      waitsFor ->
+        callback.callCount is 1
+
+      runs ->
+        expect(console.error).not.toHaveBeenCalled()
+        expect(console.log).toHaveBeenCalled()
+        lines = console.log.argsForCall[0][0].split('\n')
+        expect(lines[0]).toBe "apm  #{require('../package.json').version}"
+        expect(lines[1]).toBe "npm  #{require('npm/package.json').version}"
+        expect(lines[2]).toBe "node #{process.versions.node} #{process.arch}"
+
     describe 'when the version flag is specified and apm is unable find package.json on the resourcePath', ->
       it 'prints unknown atom version', ->
         callback = jasmine.createSpy('callback')

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -25,6 +25,9 @@ module.exports =
     if process.env.ATOM_RESOURCE_PATH
       return process.nextTick -> callback(process.env.ATOM_RESOURCE_PATH)
 
+    if asarPath # already calculated
+      return process.nextTick -> callback(asarPath)
+
     apmFolder = path.resolve(__dirname, '..')
     appFolder = path.dirname(apmFolder)
     if path.basename(apmFolder) is 'apm' and path.basename(appFolder) is 'app'
@@ -51,11 +54,10 @@ module.exports =
           appLocation = '/usr/share/atom/resources/app.asar'
         process.nextTick -> callback(appLocation)
       when 'win32'
-        if (asarPath is null)
-          glob = require 'glob'
-          pattern = "/Users/#{process.env.USERNAME}/AppData/Local/atom/app-+([0-9]).+([0-9]).+([0-9])/resources/app.asar"
-          asarPaths = glob.sync(pattern, null) # [] | a sorted array of locations with the newest version being last
-          asarPath = asarPaths[asarPaths.length - 1]
+        glob = require 'glob'
+        pattern = "/Users/#{process.env.USERNAME}/AppData/Local/atom/app-+([0-9]).+([0-9]).+([0-9])/resources/app.asar"
+        asarPaths = glob.sync(pattern, null) # [] | a sorted array of locations with the newest version being last
+        asarPath = asarPaths[asarPaths.length - 1]
         return process.nextTick -> callback(asarPath)
       else
         return process.nextTick -> callback('')

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -51,7 +51,7 @@ module.exports =
           return process.nextTick -> callback(asarPath)
       when 'linux'
         asarPath = '/usr/local/share/atom/resources/app.asar'
-        unless fs.existsSync(appLocation)
+        unless fs.existsSync(asarPath)
           asarPath = '/usr/share/atom/resources/app.asar'
         return process.nextTick -> callback(asarPath)
       when 'win32'

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -3,6 +3,7 @@ fs = require './fs'
 path = require 'path'
 npm = require 'npm'
 semver = require 'semver'
+glob = require 'glob'
 
 module.exports =
   getHomeDirectory: ->
@@ -49,6 +50,15 @@ module.exports =
         unless fs.existsSync(appLocation)
           appLocation = '/usr/share/atom/resources/app.asar'
         process.nextTick -> callback(appLocation)
+      else # Windows
+        pattern = "/Users/#{process.env.USERNAME}/AppData/Local/atom/app-+([0-9]).+([0-9]).+([0-9])/resources/app.asar"
+        glob pattern, null, (er, appLocations) ->
+          # appLocations is an array of '/absolute/paths/to/app.asar'.
+          # Array elements are sorted; Newer Atom installs are higher-versioned,
+          # So they should be sorted later in the array.
+          # If nothing was found, then appLocation is an empty array.
+          # er is an error object or null.
+          callback(appLocations.pop()) # Use the newest Atom install found (last element of appLocations).
 
   getReposDirectory: ->
     process.env.ATOM_REPOS_HOME ? path.join(@getHomeDirectory(), 'github')

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -55,7 +55,7 @@ module.exports =
           glob = require 'glob'
           pattern = "/Users/#{process.env.USERNAME}/AppData/Local/atom/app-+([0-9]).+([0-9]).+([0-9])/resources/app.asar"
           asarPaths = glob.sync(pattern, null) # [] | a sorted array of locations with the newest version being last
-          asarPath = asarPaths.pop()
+          asarPath = asarPaths[asarPaths.length - 1]
         return process.nextTick -> callback(asarPath)
       else
         return process.nextTick -> callback('')

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -47,7 +47,8 @@ module.exports =
         child_process.exec 'mdfind "kMDItemCFBundleIdentifier == \'com.github.atom\'"', (error, stdout='', stderr) ->
           [appLocation] = stdout.split('\n') unless error
           appLocation = '/Applications/Atom.app' unless appLocation
-          callback("#{appLocation}/Contents/Resources/app.asar")
+          asarPath = "#{appLocation}/Contents/Resources/app.asar"
+          return process.nextTick -> callback(asarPath)
       when 'linux'
         appLocation = '/usr/local/share/atom/resources/app.asar'
         unless fs.existsSync(appLocation)

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -50,10 +50,10 @@ module.exports =
           asarPath = "#{appLocation}/Contents/Resources/app.asar"
           return process.nextTick -> callback(asarPath)
       when 'linux'
-        appLocation = '/usr/local/share/atom/resources/app.asar'
+        asarPath = '/usr/local/share/atom/resources/app.asar'
         unless fs.existsSync(appLocation)
-          appLocation = '/usr/share/atom/resources/app.asar'
-        process.nextTick -> callback(appLocation)
+          asarPath = '/usr/share/atom/resources/app.asar'
+        return process.nextTick -> callback(asarPath)
       when 'win32'
         glob = require 'glob'
         pattern = "/Users/#{process.env.USERNAME}/AppData/Local/atom/app-+([0-9]).+([0-9]).+([0-9])/resources/app.asar"

--- a/src/apm.coffee
+++ b/src/apm.coffee
@@ -57,6 +57,8 @@ module.exports =
           asarPaths = glob.sync(pattern, null) # [] | a sorted array of locations with the newest version being last
           asarPath = asarPaths.pop()
         return process.nextTick -> callback(asarPath)
+      else
+        return process.nextTick -> callback('')
 
   getReposDirectory: ->
     process.env.ATOM_REPOS_HOME ? path.join(@getHomeDirectory(), 'github')


### PR DESCRIPTION
### Description of the Change

- This fixes getResourcePath so it finds the installation location on Windows. It results in the correct behavior of several `apm` commands (such as apm --version) when apm isn't bundled with Atom.

- It also optimizes getResourcePath by storing a cache of the asarPath. This means asarPath is only calculated once.

### Benefits

Allows more `apm` commands (examples: `apm --version`, `apm install [package-name]`)
to work on Windows, even outside of a full Atom installation. For example:

- Allows `apm --version` to work during the Atom bootstrap script.
- Allows testing apm from inside its own git repository on Windows.

### Possible Drawbacks

None.

### Verification Process

The tests are included: https://github.com/atom/apm/pull/906/files#diff-845586f656569b8df7748376c8e75465R47

Manual tests:

Manually ran `apm --version` in the `apm` Git repo. Output is useful and not blank.

<details><summary>Sample output (click to expand):</summary>

```ps1
PS C:\Users\User\Downloads\apm> .\bin\apm.cmd --version
apm  2.5.2-atomic.2
npm  6.14.8
node 12.4.0 x64
atom 1.51.0
python 2.7.18
git 2.27.0.windows.1
visual studio 2019
```

</details>

Manually ran `.\bin\apm.cmd install hydrogen`. Package now installs. (Before this PR, the command quickly exits with no logging or output.)

Also, CI should pass.

### Applicable Issues

<!-- Enter any applicable Issues here -->

None.

### Extra info
TL;DR

<details><summary>Info about what getResourcePath() does</summary>

The `getResourcePath()` function's job is to find an install of Atom on the disk. (Specifically, it gives the path to the `app.asar` [application package/archive](https://www.electronjs.org/docs/tutorial/application-packaging) that holds most of Atom's JS code, bundled packages, various binaries, and so on.

</details>

Because Atom install paths on Windows are version-specific, and because at least the previous version is meant to stay around after an update, users may have more than one Atom install, and we have to pick one of the multiple installs. In this case, I just made sure to pick the newest install (among installs having a `resources/app.asar` file).

<details><summary>Long explanation (click to expand):</summary>

After adding this fallback behavior, apm should be able to find stable installations of Atom on the disk, even when apm isn't bundled with the Atom install it's looking for.

(This mostly requires that the user have an Atom installation on disk. But it also makes `apm` behave slightly better even when there is no Atom installed to disk. For example, `apm --version` used to print nothing at all on Windows when apm wasn't bundled with Atom. Now it will print all versions it can find. If there was no Atom install found on disk, the Atom version will now print as "`unknown`". `apm install` will give you the relevant error message `Could not determine Electron version` rather than exiting with no logging or output at all.)

</details>