### PR TITLE
 Respect the "NO_APM_DEDUPE" env var on Windows (for the postinstall script)

### DIFF
--- a/script/postinstall.cmd
+++ b/script/postinstall.cmd
@@ -10,6 +10,11 @@ for /f "delims=" %%i in ('.\bin\node.exe -p "process.version + ' ' + process.arc
 echo ^>^> Rebuilding apm dependencies with bundled Node !bundledVersion!
 call .\bin\npm.cmd rebuild
 
-echo.
-echo ^>^> Deduping apm dependencies
-call .\bin\npm.cmd dedupe
+if defined NO_APM_DEDUPE (
+    echo.
+    echo ^>^> Deduplication disabled
+) else (
+    echo.
+    echo ^>^> Deduping apm dependencies
+    call .\bin\npm.cmd dedupe
+)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Linux and macOS have respected a `NO_APM_DEDUPE` env var for a long time. When this env var is set, the `postinstall` script skips running `npm dedupe`.

This PR adds a few lines to the Windows-specific `script\postinstall.cmd` file to do the same thing on Windows.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- Make deduping off by default (actually, I think I prefer this over "deduping is on by default", now that I'm thinking about it.)
- Remove deduping entirely from the `postinstall` script. (This would also be a good option).

### Benefits

<!-- What benefits will be realized by the code change? -->

This enables installing `apm` with `npm ci` in the Atom repository.

Which in turn means we can have reliable, stable bootstrapping, when desired, for the Atom repo. No unexpected dependency changes, and no more hard-to-troubleshoot and hard-to-fix build failures.

_(Note: Attempting to "disable deduping" may not work when installing `apm` as a git URL dependency. But installing `apm` as a git URL depoendency has already been buggy for a long time, regardless of this PR. And this PR would not be a regression, just that the improvement here may not apply to `apm` as a git URL dependency.)_

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

For this repository on its own:

I ran `npm run postinstall` and `npm install` with this env var set (`set NO_APM_DEDUPE=true` in `cmd.exe`).

Deduping was successfully skipped, and a message was printed out (`>> Deduplication disabled`) to indicate that this is happening on purpose.

---

For testing out installing `apm` in Atom with `npm ci`:
- `cd atom\apm`
- Set `NO_APM_DEDUPE=true`
- `npm ci`
- _While this PR is pending, testing this feature with Atom requires patching `apm` in-place to use the updated `script\postinstall.cmd`._
  - During `npm ci`, quickly after `apm` is extracted, copy the modified `script\postinstall.cmd` and paste to overwrite the existing, non-patched one in `atom\apm\node_modules\atom-package-manager\script\postinstall.cmd`.  
  -  _(Live-patching this file on Windows will no-longer be needed once this PR is merged and shipped in a stable release of `apm`.)_
  - If you are on Linux or macOS, then there is no need to copy or patch any files; The flag is already respected on Linux/macOS.
- Observe that the following is printed at the end: `>> Deduplication disabled`
- Run `npm ls`, and observe that no packages are reported missing.

### Applicable Issues

<!-- Enter any applicable Issues here -->

None.