### PR TITLE
script: Remove automatic deduping from postinstall

### DIFF
--- a/script/postinstall.cmd
+++ b/script/postinstall.cmd
@@ -9,12 +9,3 @@ echo.
 for /f "delims=" %%i in ('.\bin\node.exe -p "process.version + ' ' + process.arch"') do set bundledVersion=%%i
 echo ^>^> Rebuilding apm dependencies with bundled Node !bundledVersion!
 call .\bin\npm.cmd rebuild
-
-if defined NO_APM_DEDUPE (
-    echo.
-    echo ^>^> Deduplication disabled
-) else (
-    echo.
-    echo ^>^> Deduping apm dependencies
-    call .\bin\npm.cmd dedupe
-)

--- a/script/postinstall.sh
+++ b/script/postinstall.sh
@@ -8,11 +8,3 @@ node script/download-node.js
 echo
 echo ">> Rebuilding apm dependencies with bundled Node $(./bin/node -p "process.version + ' ' + process.arch")"
 ./bin/npm rebuild
-
-echo
-if [ -z "${NO_APM_DEDUPE}" ]; then
-  echo ">> Deduping apm dependencies"
-  ./bin/npm dedupe
-else
-  echo ">> Deduplication disabled"
-fi


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR removes a couple of lines in `script/postinstall.cmd` and `script/postinstall.sh` that performed an `npm dedupe` toward the end of the `postinstall` script when installing `apm` itself.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- Could keep automatic deduping in, but make it off by default/enabled with an env var
  - (I wonder if anyone would use the env var and enable deduping? Is that any easier than just running `npm dedupe` manually?)
  - Example implementation: [`381120d..a93c88a`](https://github.com/DeeDeeG/apm/compare/381120d1616d9896277a49f04ead807d8958b039..a93c88ab28e2c38f5c75c5240ac5188db9af6b8d)
- Could keep the status quo where it is on by default but can be disabled with an env var
  - (it seems to me that automatic deduping can cause problems and should not be on by default.)

I think off by default is justified, but removing the capability altogether is even cleaner to simplify the code. If a user wants to ensure apm is installed with maximum deduping, they can delete `apm`'s `node_modules` folder and its `package-lock.json`, and reinstall.

In my experience, the extra `npm dedupe` run makes no difference.

### Benefits

<!-- What benefits will be realized by the code change? -->

Faster installs of `apm` itself (by skipping deduping). No more missing dependencies when installing `apm` with `npm ci`; Makes installing `apm` with `npm ci` possible without having to set the `NO_APM_DEDUPE` env var anymore.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

(Very small?) chance of missing some deduping/filesize savings when upgrading apm in the Atom repo.

To give modern `npm` the easiest time with its own automated/internal deduping when updating `apm` in the Atom repo, I recommend deleting `apm`'s `node_modules` and `package-lock.json`, then updating its `package.json` to the newest `apm`, then running `npm install --global-style` as usual.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

As intended with this change, `npm dedupe` is no-longer run during the `postinstall` script. I have tried this many times locally, and this has been in the community fork for several months now, including in CI.

### Applicable Issues

<!-- Enter any applicable Issues here -->

Upstreaming this PR from the `atom-community` fork of `apm`: https://github.com/atom-community/apm/pull/71

As requested by @sadick254 in https://github.com/atom/atom/pull/22450#pullrequestreview-663591215.